### PR TITLE
143354_add_tool-versions_to_hex_package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,6 @@ which are exposed to antikythera instance administrators and/or gear developers.
 
 ---
 
-- 0.1.1:
+- 0.2.0:
     - Rate limiting on accesses to async job queues was introduced.
     - `.tool-versions` file was included in hex package. Antikythera fetched from hex.pm should now be properly compiled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,6 @@ which are exposed to antikythera instance administrators and/or gear developers.
 
 ---
 
-- In the next minor version:
+- 0.1.1:
     - Rate limiting on accesses to async job queues was introduced.
+    - `.tool-versions` file was included in hex package. Antikythera fetched from hex.pm should now be properly compiled.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Antikythera Framework
 
+[![hex badge](https://img.shields.io/hexpm/v/antikythera.svg)](https://hex.pm/packages/antikythera)
+
 **Antikythera** is an [Elixir] framework to build your own in-house PaaS (Platform as a Service).
 
 You can run multiple web services while managing only a single cluster of [ErlangVM][Erlang] nodes.

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Antikythera.Mixfile do
   def project() do
     [
       app:             :antikythera,
-      version:         "0.1.1",
+      version:         "0.2.0",
       elixirc_paths:   elixirc_paths(),
       start_permanent: Mix.env() == :prod,
       deps:            deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Antikythera.Mixfile do
   def project() do
     [
       app:             :antikythera,
-      version:         Antikythera.MixCommon.version_with_last_commit_info("0.1.1"),
+      version:         "0.1.1",
       elixirc_paths:   elixirc_paths(),
       start_permanent: Mix.env() == :prod,
       deps:            deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -131,7 +131,7 @@ defmodule Antikythera.Mixfile do
       links:       %{"GitHub" => @github_url},
       files:       [
         "core", "eal", "lib", "local", "priv", "rel",
-        "CHANGELOG.md", "LICENSE", "mix_common.exs", "mix.exs", "README.md",
+        "CHANGELOG.md", "LICENSE", "mix_common.exs", "mix.exs", "README.md", ".tool-versions",
       ],
     ]
   end


### PR DESCRIPTION
- Include missing `.tool-versions` in hex package, as it is currently required by erlang/elixir version checks in mix_common.exs

(https://acsmine.tok.access-company.com/redmine/issues/143354)