### PR TITLE
[133779] Refactoring about regex

### DIFF
--- a/core/gear_log/file_handle.ex
+++ b/core/gear_log/file_handle.ex
@@ -80,7 +80,7 @@ defmodule AntikytheraCore.GearLog.FileHandle do
     import Antikythera.StringFormat
     {Time, {y, mon, d}, {h, minute, s}, _ms} = Time.now()
     now_str_with_ext = "#{y}#{pad2(mon)}#{pad2(d)}#{pad2(h)}#{pad2(minute)}#{pad2(s)}.gz"
-    String.replace(base_file_path, ~r/gz$/, now_str_with_ext)
+    String.replace(base_file_path, ~R/gz\z/, now_str_with_ext)
   end
 
   if Antikythera.Env.compiling_for_release?() do

--- a/core/web/request.ex
+++ b/core/web/request.ex
@@ -25,7 +25,7 @@ defmodule AntikytheraCore.Request do
         :inet.ntoa(ip) |> List.to_string()
       ip_str ->
         # Take the last IP address in "x-forwarded-for" as it is added by reliable component (upstream load balancer).
-        String.split(ip_str, ~r/, */) |> List.last()
+        String.split(ip_str, ~R/, */) |> List.last()
     end
   end
 end

--- a/lib/type/async_job.ex
+++ b/lib/type/async_job.ex
@@ -3,7 +3,7 @@
 use Croma
 
 defmodule Antikythera.AsyncJob.Id do
-  use Croma.SubtypeOfString, pattern: ~r/^[0-9A-Za-z_-]{1,32}$/
+  use Croma.SubtypeOfString, pattern: ~R/\A[0-9A-Za-z_-]{1,32}\z/
 
   defun generate() :: t do
     Enum.map(1..20, fn _ -> gen_base64url_char() end) |> List.to_string()

--- a/lib/type/http.ex
+++ b/lib/type/http.ex
@@ -53,7 +53,7 @@ defmodule Antikythera.Http do
     }
 
     defun parse!(s :: v[String.t]) :: {String.t, t} do
-      [pair | attrs] = String.split(s, ~r/\s*;\s*/)
+      [pair | attrs] = String.split(s, ~R/\s*;\s*/)
       [name, value] = String.split(pair, "=", parts: 2)
       cookie =
         Enum.reduce(attrs, %__MODULE__{value: value}, fn(attr, acc) ->
@@ -66,7 +66,7 @@ defmodule Antikythera.Http do
     end
 
     defp attr_to_opt(attr) do
-      [name | rest] = String.split(attr, ~r/\s*=\s*/, parts: 2)
+      [name | rest] = String.split(attr, ~R/\s*=\s*/, parts: 2)
       case String.downcase(name) do
         "path"     -> {:path     , hd(rest)}
         "domain"   -> {:domain   , hd(rest)}

--- a/lib/type/string.ex
+++ b/lib/type/string.ex
@@ -19,7 +19,7 @@ defmodule Antikythera.VersionStr do
   this is just to simplify deployment and not an intrinsic limitation.
   """
 
-  use Croma.SubtypeOfString, pattern: ~r/^\d\.\d\.\d-\d{14}\+[0-9a-f]{40}$/
+  use Croma.SubtypeOfString, pattern: ~R/\A\d\.\d\.\d-\d{14}\+[0-9a-f]{40}\z/
 end
 
 defmodule Antikythera.Domain do
@@ -34,7 +34,7 @@ defmodule Antikythera.Domain do
   @pattern_body "((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)*(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
   def pattern_body(), do: @pattern_body
 
-  use Croma.SubtypeOfString, pattern: ~r/^#{@pattern_body}$/
+  use Croma.SubtypeOfString, pattern: ~r/\A#{@pattern_body}\z/
 end
 
 defmodule Antikythera.DomainList do
@@ -52,7 +52,7 @@ defmodule Antikythera.PathSegment do
   @charclass "[0-9A-Za-z\-._~%!$&'()*+,;=:@]"
   def charclass(), do: @charclass
 
-  use Croma.SubtypeOfString, pattern: ~r|^#{@charclass}*$|
+  use Croma.SubtypeOfString, pattern: ~r|\A#{@charclass}*\z|
 end
 
 defmodule Antikythera.PathInfo do
@@ -63,12 +63,12 @@ defmodule Antikythera.UnencodedPath do
   @segment_charclass "[^/?#]"
   def segment_charclass(), do: @segment_charclass
 
-  use Croma.SubtypeOfString, pattern: ~r"\A/(#{@segment_charclass}+/)*(#{@segment_charclass}+)?\Z"
+  use Croma.SubtypeOfString, pattern: ~r"\A/(#{@segment_charclass}+/)*(#{@segment_charclass}+)?\z"
 end
 
 defmodule Antikythera.EncodedPath do
   alias Antikythera.PathSegment, as: Segment
-  use Croma.SubtypeOfString, pattern: ~r"\A/(#{Segment.charclass()}+/)*(#{Segment.charclass()}+)?\Z"
+  use Croma.SubtypeOfString, pattern: ~r"\A/(#{Segment.charclass()}+/)*(#{Segment.charclass()}+)?\z"
 end
 
 defmodule Antikythera.Url do
@@ -91,7 +91,7 @@ defmodule Antikythera.Url do
   captured_ip_pattern = "(?<ip_str>(\\d{1,3}\\.){3}\\d{1,3})"
   host_pattern        = "(#{captured_ip_pattern}|#{Domain.pattern_body()})"
   path_pattern        = "((/[^/ ?#]+)*/?)?"
-  @pattern              ~r"^https?://([^ :]+(:[^ :]+)?@)?#{host_pattern}(:\d{1,5})?#{path_pattern}(\?([^ #]*))?(#[^ ]*)?$"
+  @pattern              ~r"\Ahttps?://([^ :]+(:[^ :]+)?@)?#{host_pattern}(:\d{1,5})?#{path_pattern}(\?([^ #]*))?(#[^ ]*)?\z"
   def pattern(), do: @pattern
 
   defun valid?(v :: term) :: boolean do
@@ -117,14 +117,14 @@ defmodule Antikythera.Email do
   - Total length of domain parts are not limited to 255.
   """
 
-  use Croma.SubtypeOfString, pattern: ~r"^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]{1,64}@#{Antikythera.Domain.pattern_body()}$"
+  use Croma.SubtypeOfString, pattern: ~r"\A[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]{1,64}@#{Antikythera.Domain.pattern_body()}\z"
 end
 
 defmodule Antikythera.ContextId do
   @system_context "antikythera_system"
   def system_context(), do: @system_context
 
-  use Croma.SubtypeOfString, pattern: ~r/^(\d{8}-\d{6}\.\d{3}_[0-9A-Za-z.-]+_\d+\.\d+\.\d+|#{@system_context})$/
+  use Croma.SubtypeOfString, pattern: ~r/\A(\d{8}-\d{6}\.\d{3}_[0-9A-Za-z.-]+_\d+\.\d+\.\d+|#{@system_context})\z/
 end
 
 defmodule Antikythera.ImfFixdate do
@@ -135,7 +135,7 @@ defmodule Antikythera.ImfFixdate do
 
   days_of_week = "(Mon|Tue|Wed|Thu|Fri|Sat|Sun)"
   months_of_year = "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"
-  use Croma.SubtypeOfString, pattern: ~r/^#{days_of_week}, \d\d #{months_of_year} \d\d\d\d \d\d:\d\d:\d\d GMT$/
+  use Croma.SubtypeOfString, pattern: ~r/\A#{days_of_week}, \d\d #{months_of_year} \d\d\d\d \d\d:\d\d:\d\d GMT\z/
 end
 
 defmodule Antikythera.GearName do
@@ -154,12 +154,12 @@ defmodule Antikythera.GearName do
 end
 
 defmodule Antikythera.GearNameStr do
-  use Croma.SubtypeOfString, pattern: ~r/^[a-z][0-9a-z_]{2,31}$/
+  use Croma.SubtypeOfString, pattern: ~R/\A[a-z][0-9a-z_]{2,31}\z/
 end
 
 defmodule Antikythera.TenantId do
   @notenant "notenant"
   defun notenant() :: String.t, do: @notenant
 
-  use Croma.SubtypeOfString, pattern: ~r/^(?!^#{@notenant}$)\w{3,32}$/
+  use Croma.SubtypeOfString, pattern: ~r/\A(?!^#{@notenant}$)\w{3,32}\z/
 end

--- a/lib/web/router/impl.ex
+++ b/lib/web/router/impl.ex
@@ -62,7 +62,7 @@ defmodule Antikythera.Router.Impl do
   end
 
   defunp correct_format?(segment :: v[PathSegment.t]) :: boolean do
-    Regex.match?(~r/^(([0-9A-Za-z.~_-]*)|([:*][a-z_][0-9a-z_]*))$/, segment)
+    Regex.match?(~R/\A(([0-9A-Za-z.~_-]*)|([:*][a-z_][0-9a-z_]*))\z/, segment)
   end
 
   defunp placeholder_names_uniq?(segments :: v[PathInfo.t]) :: boolean do

--- a/lib/web/router/router.ex
+++ b/lib/web/router/router.ex
@@ -214,7 +214,7 @@ defmodule Antikythera.Router do
 
   defmacro static_prefix(prefix) do
     quote bind_quoted: [prefix: prefix] do
-      if prefix =~ ~r|^(/[0-9A-Za-z.~_-]+)+$| do
+      if prefix =~ ~R|\A(/[0-9A-Za-z.~_-]+)+\z| do
         def static_prefix(), do: unquote(prefix)
       else
         raise "invalid path prefix given to `static_prefix/1`: #{prefix}"

--- a/local/mix/version_upgrade_test.ex
+++ b/local/mix/version_upgrade_test.ex
@@ -108,8 +108,8 @@ defmodule Mix.Tasks.AntikytheraLocal.VersionUpgradeTest do
   defunp override_version_in_mix_file(app_name :: g[atom], new_version :: g[String.t], mixfile_path :: Path.t) :: :ok do
     replacement = "\\1\"#{new_version}\"\\3"
     case app_name do
-      @instance_name -> override_file(mixfile_path, ~r/(version\:[^\(]+\()([^\)]+)(\),\n)/   , replacement)
-      :testgear      -> override_file(mixfile_path, ~r/(defp\sversion[^\:]+\:\s)([^\n]+)(\n)/, replacement)
+      @instance_name -> override_file(mixfile_path, ~R/(version\:[^\(]+\()([^\)]+)(\),\n)/   , replacement)
+      :testgear      -> override_file(mixfile_path, ~R/(defp\sversion[^\:]+\:\s)([^\n]+)(\n)/, replacement)
     end
   end
 


### PR DESCRIPTION
- use "\A" and "\z" instead of "^" and "$"
- use "~R" when there are no interpolations

Ticket: https://acsmine.tok.access-company.com/redmine/issues/133779