### PR TITLE
[145135] Disable gear upgrades when a node recognizes that it's about to be terminated

### DIFF
--- a/core/sup_tree_core/termination_manager.ex
+++ b/core/sup_tree_core/termination_manager.ex
@@ -22,6 +22,7 @@ defmodule AntikytheraCore.TerminationManager do
   defmodule State do
     alias AntikytheraCore.ExecutorPool.AsyncJobBroker
     alias AntikytheraCore.ExecutorPool.WebsocketConnectionsCounter
+    alias AntikytheraCore.VersionUpgradeTaskQueue
 
     use Croma.Struct, recursive_new?: true, fields: [
       in_service?:          Croma.Boolean,
@@ -36,6 +37,7 @@ defmodule AntikytheraCore.TerminationManager do
       new_count = if now_in_service?, do: 0, else: count + 1
       if in_service? and new_count >= @threshold_count do
         L.info("confirmed that this host is to be terminated; start cleanup...")
+        VersionUpgradeTaskQueue.disable_version_upgrade()
         cleanup(brokers)
         %State{state | in_service?: false, not_in_service_count: new_count}
       else

--- a/core/sup_tree_core/termination_manager.ex
+++ b/core/sup_tree_core/termination_manager.ex
@@ -37,7 +37,7 @@ defmodule AntikytheraCore.TerminationManager do
       new_count = if now_in_service?, do: 0, else: count + 1
       if in_service? and new_count >= @threshold_count do
         L.info("confirmed that this host is to be terminated; start cleanup...")
-        VersionUpgradeTaskQueue.disable_version_upgrade()
+        VersionUpgradeTaskQueue.disable()
         cleanup(brokers)
         %State{state | in_service?: false, not_in_service_count: new_count}
       else

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -77,18 +77,18 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
   # Public API
   #
   defun gear_updated(gear_name :: v[GearName.t]) :: :ok do
-    :ok = GenServer.cast(__MODULE__, {:gear_updated, gear_name})
+    GenServer.cast(__MODULE__, {:gear_updated, gear_name})
   end
 
   defun core_updated() :: :ok do
-    :ok = GenServer.cast(__MODULE__, :core_updated)
+    GenServer.cast(__MODULE__, :core_updated)
   end
 
-  defun enable_version_upgrade() :: :ok do
-    :ok = GenServer.cast(__MODULE__, :enable_version_upgrade)
+  defun enable() :: :ok do
+    GenServer.cast(__MODULE__, :enable_version_upgrade)
   end
 
-  defun disable_version_upgrade() :: :ok do
-    :ok = GenServer.cast(__MODULE__, :disable_version_upgrade)
+  defun disable() :: :ok do
+    GenServer.cast(__MODULE__, :disable_version_upgrade)
   end
 end

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -65,11 +65,11 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
     end
   end
 
-  defp run_task({:gear_updated, gear_name}) do
+  defp run_task({:gear, gear_name}) do
     {pid, _ref} = spawn_monitor(Version.Gear, :install_or_upgrade_to_next_version, [gear_name])
     pid
   end
-  defp run_task(:core_updated) do
+  defp run_task(:core) do
     {pid, _ref} = spawn_monitor(Version.Core, :upgrade_to_next_version, [])
     pid
   end
@@ -78,11 +78,11 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
   # Public API
   #
   defun gear_updated(gear_name :: v[GearName.t]) :: :ok do
-    GenServer.cast(__MODULE__, {:upgrade, {:gear_updated, gear_name}})
+    GenServer.cast(__MODULE__, {:upgrade, {:gear, gear_name}})
   end
 
   defun core_updated() :: :ok do
-    GenServer.cast(__MODULE__, {:upgrade, :core_updated})
+    GenServer.cast(__MODULE__, {:upgrade, :core})
   end
 
   defun enable() :: :ok do

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -58,7 +58,7 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
     if pid == nil and enabled? do
       case :queue.out(q) do
         {{:value, instruction}, new_queue} -> %{state | queue: new_queue, task_pid: run_task(instruction)}
-        {:empty           , _        } -> state
+        {:empty               , _        } -> state
       end
     else
       state

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -54,7 +54,7 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
     {:noreply, new_state}
   end
 
-  defp run_task_if_possible(%{queue: q, task_pid: pid, enable_upgrade?: enable?} = state) do
+  defp run_task_if_possible(%{queue: q, task_pid: pid, enable?: enable?} = state) do
     if pid == nil and enable? do
       case :queue.out(q) do
         {{:value, message}, new_queue} -> %{state | queue: new_queue, task_pid: run_task(message)}

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -29,14 +29,14 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
   def handle_cast(message, state) do
     new_state =
       case message do
-        {:upgrade    , instruction} -> enqueue_message(state, instruction) |> run_task_if_possible()
+        {:upgrade    , instruction} -> enqueue_instruction(state, instruction) |> run_task_if_possible()
         {:set_enabled, enabled?   } -> set_enabled(state, enabled?)
       end
     {:noreply, new_state}
   end
 
-  defp enqueue_message(%{queue: q} = state, message) do
-    %{state | queue: :queue.in(message, q)}
+  defp enqueue_instruction(%{queue: q} = state, instruction) do
+    %{state | queue: :queue.in(instruction, q)}
   end
 
   defp set_enabled(state, enabled?) do

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -54,8 +54,8 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
     {:noreply, new_state}
   end
 
-  defp run_task_if_possible(%{queue: q, task_pid: pid, enable?: enable?} = state) do
-    if pid == nil and enable? do
+  defp run_task_if_possible(%{queue: q, task_pid: pid, enabled?: enabled?} = state) do
+    if pid == nil and enabled? do
       case :queue.out(q) do
         {{:value, message}, new_queue} -> %{state | queue: new_queue, task_pid: run_task(message)}
         {:empty           , _        } -> state

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -57,7 +57,7 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
   defp run_task_if_possible(%{queue: q, task_pid: pid, enabled?: enabled?} = state) do
     if pid == nil and enabled? do
       case :queue.out(q) do
-        {{:value, message}, new_queue} -> %{state | queue: new_queue, task_pid: run_task(message)}
+        {{:value, instruction}, new_queue} -> %{state | queue: new_queue, task_pid: run_task(instruction)}
         {:empty           , _        } -> state
       end
     else


### PR DESCRIPTION
- Add function to enable / disable upgrade of antikythera instance or gears in VersionUpgradeTaskQueue

https://acsmine.tok.access-company.com/redmine/issues/145135