### PR TITLE
[133886] Refactoring: Change scheme to specify supervisor spec

### DIFF
--- a/core/core.ex
+++ b/core/core.ex
@@ -4,7 +4,6 @@ use Croma
 
 defmodule AntikytheraCore do
   use Application
-  alias Supervisor.Spec
 
   @impl true
   def start(_type, _args) do
@@ -75,25 +74,25 @@ defmodule AntikytheraCore do
 
   defp start_sup() do
     children = [
-      Spec.worker(    AntikytheraCore.ErrorCountsAccumulator    , []),
-      Spec.worker(    AntikytheraCore.Alert.Manager             , [:antikythera, AntikytheraCore.Alert.Manager]),
-      Spec.worker(    AntikytheraCore.GearManager               , []),
-      Spec.worker(    AntikytheraCore.ClusterHostsPoller        , []),
-      Spec.worker(    AntikytheraCore.ClusterNodesConnector     , []),
-      Spec.worker(    AntikytheraCore.MnesiaNodesCleaner        , []),
-      Spec.worker(    AntikytheraCore.StartupManager            , []),
-      Spec.worker(    AntikytheraCore.TerminationManager        , []),
-      Spec.worker(    AntikytheraCore.CoreConfigPoller          , []),
-      Spec.worker(    AntikytheraCore.GearConfigPoller          , []),
-      Spec.worker(    AntikytheraCore.VersionUpgradeTaskQueue   , []),
-      Spec.worker(    AntikytheraCore.VersionSynchronizer       , []),
-      Spec.worker(    AntikytheraCore.StaleGearArtifactCleaner  , []),
-      Spec.worker(    AntikytheraCore.MetricsUploader           , [:antikythera, AntikytheraCore.MetricsUploader]),
-      Spec.worker(    AntikytheraCore.SystemMetricsReporter     , [AntikytheraCore.MetricsUploader]),
-      Spec.supervisor(AntikytheraCore.ExecutorPool.Sup          , []),
-      Spec.worker(    AntikytheraCore.GearExecutorPoolsManager  , []),
-      Spec.worker(    AntikytheraCore.TenantExecutorPoolsManager, []),
-      Spec.worker(    AntikytheraCore.TmpdirTracker             , []),
+      AntikytheraCore.ErrorCountsAccumulator    ,
+      {AntikytheraCore.Alert.Manager            , [:antikythera, AntikytheraCore.Alert.Manager]},
+      AntikytheraCore.GearManager               ,
+      AntikytheraCore.ClusterHostsPoller        ,
+      AntikytheraCore.ClusterNodesConnector     ,
+      AntikytheraCore.MnesiaNodesCleaner        ,
+      AntikytheraCore.StartupManager            ,
+      AntikytheraCore.TerminationManager        ,
+      AntikytheraCore.CoreConfigPoller          ,
+      AntikytheraCore.GearConfigPoller          ,
+      AntikytheraCore.VersionUpgradeTaskQueue   ,
+      AntikytheraCore.VersionSynchronizer       ,
+      AntikytheraCore.StaleGearArtifactCleaner  ,
+      {AntikytheraCore.MetricsUploader          , [:antikythera, AntikytheraCore.MetricsUploader]},
+      {AntikytheraCore.SystemMetricsReporter    , [AntikytheraCore.MetricsUploader]},
+      AntikytheraCore.ExecutorPool.Sup          ,
+      AntikytheraCore.GearExecutorPoolsManager  ,
+      AntikytheraCore.TenantExecutorPoolsManager,
+      AntikytheraCore.TmpdirTracker             ,
     ]
     opts = [strategy: :one_for_one, name: AntikytheraCore.Supervisor]
     Supervisor.start_link(children, opts)

--- a/core/sup_tree_common/alert_manager.ex
+++ b/core/sup_tree_common/alert_manager.ex
@@ -21,11 +21,11 @@ defmodule AntikytheraCore.Alert.Manager do
   def child_spec(args) do
     %{
       id:    __MODULE__,
-      start: {__MODULE__, :start_link, args},
+      start: {__MODULE__, :start_link, [args]},
     }
   end
 
-  def start_link(otp_app_name, name_to_register) do
+  def start_link([otp_app_name, name_to_register]) do
     {:ok, pid} = :gen_event.start_link({:local, name_to_register})
     update_handler_installations(otp_app_name, HandlerConfigsMap.get(otp_app_name))
     {:ok, pid}

--- a/core/sup_tree_common/alert_manager.ex
+++ b/core/sup_tree_common/alert_manager.ex
@@ -18,6 +18,13 @@ defmodule AntikytheraCore.Alert.Manager do
 
   @handler_module_prefix "AntikytheraCore.Alert.Handler."
 
+  def child_spec(args) do
+    %{
+      id:    __MODULE__,
+      start: {__MODULE__, :start_link, args},
+    }
+  end
+
   def start_link(otp_app_name, name_to_register) do
     {:ok, pid} = :gen_event.start_link({:local, name_to_register})
     update_handler_installations(otp_app_name, HandlerConfigsMap.get(otp_app_name))

--- a/core/sup_tree_common/metrics_uploader.ex
+++ b/core/sup_tree_common/metrics_uploader.ex
@@ -18,7 +18,7 @@ defmodule AntikytheraCore.MetricsUploader do
   @flush_interval_base    60_000
   @flush_interval_rand_max 5_000
 
-  def start_link(otp_app_name, name_to_register) do
+  def start_link([otp_app_name, name_to_register]) do
     GenServer.start_link(__MODULE__, otp_app_name, [name: name_to_register])
   end
 

--- a/core/sup_tree_core/cluster_hosts_poller.ex
+++ b/core/sup_tree_core/cluster_hosts_poller.ex
@@ -21,7 +21,7 @@ defmodule AntikytheraCore.ClusterHostsPoller do
     end
   end
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/cluster_hosts_poller.ex
+++ b/core/sup_tree_core/cluster_hosts_poller.ex
@@ -21,7 +21,7 @@ defmodule AntikytheraCore.ClusterHostsPoller do
     end
   end
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/cluster_nodes_connector.ex
+++ b/core/sup_tree_core/cluster_nodes_connector.ex
@@ -13,7 +13,7 @@ defmodule AntikytheraCore.ClusterNodesConnector do
   alias AntikytheraCore.Cluster
   alias AntikytheraCore.ClusterHostsPoller
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/cluster_nodes_connector.ex
+++ b/core/sup_tree_core/cluster_nodes_connector.ex
@@ -13,7 +13,7 @@ defmodule AntikytheraCore.ClusterNodesConnector do
   alias AntikytheraCore.Cluster
   alias AntikytheraCore.ClusterHostsPoller
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/core_config_poller.ex
+++ b/core/sup_tree_core/core_config_poller.ex
@@ -13,7 +13,7 @@ defmodule AntikytheraCore.CoreConfigPoller do
 
   @interval 60_000
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [])
   end
 

--- a/core/sup_tree_core/core_config_poller.ex
+++ b/core/sup_tree_core/core_config_poller.ex
@@ -13,7 +13,7 @@ defmodule AntikytheraCore.CoreConfigPoller do
 
   @interval 60_000
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [])
   end
 

--- a/core/sup_tree_core/error_counts_accumulator.ex
+++ b/core/sup_tree_core/error_counts_accumulator.ex
@@ -78,7 +78,7 @@ defmodule AntikytheraCore.ErrorCountsAccumulator do
     end
   end
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/error_counts_accumulator.ex
+++ b/core/sup_tree_core/error_counts_accumulator.ex
@@ -78,7 +78,7 @@ defmodule AntikytheraCore.ErrorCountsAccumulator do
     end
   end
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/executor_pool/async_job_broker.ex
+++ b/core/sup_tree_core/executor_pool/async_job_broker.ex
@@ -43,7 +43,7 @@ defmodule AntikytheraCore.ExecutorPool.AsyncJobBroker do
     ]
   end
 
-  def start_link(pool_name, queue_name, broker_name) do
+  def start_link([pool_name, queue_name, broker_name]) do
     GenServer.start_link(__MODULE__, {pool_name, queue_name}, [name: broker_name])
   end
 

--- a/core/sup_tree_core/executor_pool/executor_pool.ex
+++ b/core/sup_tree_core/executor_pool/executor_pool.ex
@@ -18,9 +18,10 @@ defmodule AntikytheraCore.ExecutorPool do
 
   def child_spec(args) do
     %{
-      id:    __MODULE__,
-      start: {__MODULE__, :start_link, args},
-      type:  :supervisor,
+      id:       __MODULE__,
+      start:    {__MODULE__, :start_link, args},
+      shutdown: :infinity,
+      type:     :supervisor,
     }
   end
 

--- a/core/sup_tree_core/executor_pool/executor_pool.ex
+++ b/core/sup_tree_core/executor_pool/executor_pool.ex
@@ -35,12 +35,12 @@ defmodule AntikytheraCore.ExecutorPool do
     ws_counter_name = RegName.websocket_connections_counter_unsafe(epool_id)
 
     children = [
-      {PoolSup.Multi               , action_runner_pool_multi_args(epool_id, n_pools_a, size_a) },
-      {PoolSup                     , async_job_runner_pool_args(epool_id, size_j, job_pool_name)},
-      {JobBroker                   , [job_pool_name, queue_name, broker_name]                   },
-      {TimedJobStarter             , [queue_name, uploader, epool_id]                           },
-      {WebsocketConnectionsCounter , [ws_max, ws_counter_name]                                  },
-      {UsageReporter               , [uploader, epool_id]                                       },
+      {PoolSup.Multi              , action_runner_pool_multi_args(epool_id, n_pools_a, size_a) },
+      {PoolSup                    , async_job_runner_pool_args(epool_id, size_j, job_pool_name)},
+      {JobBroker                  , [job_pool_name, queue_name, broker_name]                   },
+      {TimedJobStarter            , [queue_name, uploader, epool_id]                           },
+      {WebsocketConnectionsCounter, [ws_max, ws_counter_name]                                  },
+      {UsageReporter              , [uploader, epool_id]                                       },
     ]
     Supervisor.start_link(children, [strategy: :one_for_one, name: sup_name])
   end

--- a/core/sup_tree_core/executor_pool/executor_pool.ex
+++ b/core/sup_tree_core/executor_pool/executor_pool.ex
@@ -17,6 +17,14 @@ defmodule AntikytheraCore.ExecutorPool do
 
   @wait_time_for_broker_termination (if Mix.env() == :test, do: 100, else: TenantExecutorPoolsManager.polling_interval() * 2)
 
+  def child_spec(args) do
+    %{
+      id:    __MODULE__,
+      start: {__MODULE__, :start_link, args},
+      type:  :supervisor,
+    }
+  end
+
   defun start_link(epool_id :: v[EPoolId.t],
                    uploader :: v[atom | pid],
                    %EPoolSetting{n_pools_a: n_pools_a, pool_size_a: size_a, pool_size_j: size_j, ws_max_connections: ws_max}) :: {:ok, pid} do
@@ -28,12 +36,12 @@ defmodule AntikytheraCore.ExecutorPool do
     ws_counter_name = RegName.websocket_connections_counter_unsafe(epool_id)
 
     children = [
-      Spec.supervisor(PoolSup.Multi              , action_runner_pool_multi_args(epool_id, n_pools_a, size_a)),
-      Spec.supervisor(PoolSup                    , async_job_runner_pool_args(epool_id, size_j, job_pool_name)),
-      Spec.worker(    JobBroker                  , [job_pool_name, queue_name, broker_name]),
-      Spec.worker(    TimedJobStarter            , [queue_name, uploader, epool_id]),
-      Spec.worker(    WebsocketConnectionsCounter, [ws_max, ws_counter_name]),
-      Spec.worker(    UsageReporter              , [uploader, epool_id]),
+      Spec.supervisor(PoolSup.Multi, action_runner_pool_multi_args(epool_id, n_pools_a, size_a) ),
+      Spec.supervisor(PoolSup      , async_job_runner_pool_args(epool_id, size_j, job_pool_name)),
+      {JobBroker                   , [job_pool_name, queue_name, broker_name]                   },
+      {TimedJobStarter             , [queue_name, uploader, epool_id]                           },
+      {WebsocketConnectionsCounter , [ws_max, ws_counter_name]                                  },
+      {UsageReporter               , [uploader, epool_id]                                       },
     ]
     Supervisor.start_link(children, [strategy: :one_for_one, name: sup_name])
   end
@@ -127,9 +135,16 @@ defmodule AntikytheraCore.ExecutorPool do
   end
 
   defmodule Sup do
+    def child_spec(args) do
+      %{
+        id:    __MODULE__,
+        start: {__MODULE__, :start_link, args},
+        type:  :supervisor,
+      }
+    end
+
     defun start_link() :: {:ok, pid} do
-      spec = Spec.supervisor(AntikytheraCore.ExecutorPool, [])
-      Supervisor.start_link([spec], [strategy: :simple_one_for_one, name: __MODULE__])
+      Supervisor.start_link([AntikytheraCore.ExecutorPool], [strategy: :simple_one_for_one, name: __MODULE__])
     end
   end
 end

--- a/core/sup_tree_core/executor_pool/executor_pool.ex
+++ b/core/sup_tree_core/executor_pool/executor_pool.ex
@@ -3,7 +3,6 @@
 use Croma
 
 defmodule AntikytheraCore.ExecutorPool do
-  alias Supervisor.Spec
   alias Antikythera.GearName
   alias Antikythera.ExecutorPool.Id, as: EPoolId
   alias AntikytheraCore.ExecutorPool.Setting, as: EPoolSetting
@@ -36,8 +35,8 @@ defmodule AntikytheraCore.ExecutorPool do
     ws_counter_name = RegName.websocket_connections_counter_unsafe(epool_id)
 
     children = [
-      Spec.supervisor(PoolSup.Multi, action_runner_pool_multi_args(epool_id, n_pools_a, size_a) ),
-      Spec.supervisor(PoolSup      , async_job_runner_pool_args(epool_id, size_j, job_pool_name)),
+      {PoolSup.Multi               , action_runner_pool_multi_args(epool_id, n_pools_a, size_a) },
+      {PoolSup                     , async_job_runner_pool_args(epool_id, size_j, job_pool_name)},
       {JobBroker                   , [job_pool_name, queue_name, broker_name]                   },
       {TimedJobStarter             , [queue_name, uploader, epool_id]                           },
       {WebsocketConnectionsCounter , [ws_max, ws_counter_name]                                  },

--- a/core/sup_tree_core/executor_pool/executor_pool.ex
+++ b/core/sup_tree_core/executor_pool/executor_pool.ex
@@ -137,13 +137,14 @@ defmodule AntikytheraCore.ExecutorPool do
   defmodule Sup do
     def child_spec(args) do
       %{
-        id:    __MODULE__,
-        start: {__MODULE__, :start_link, args},
-        type:  :supervisor,
+        id:       __MODULE__,
+        start:    {__MODULE__, :start_link, [args]},
+        shutdown: :infinity,
+        type:     :supervisor,
       }
     end
 
-    defun start_link() :: {:ok, pid} do
+    defun start_link(_arg) :: {:ok, pid} do
       Supervisor.start_link([AntikytheraCore.ExecutorPool], [strategy: :simple_one_for_one, name: __MODULE__])
     end
   end

--- a/core/sup_tree_core/executor_pool/executor_pool.ex
+++ b/core/sup_tree_core/executor_pool/executor_pool.ex
@@ -146,7 +146,7 @@ defmodule AntikytheraCore.ExecutorPool do
       }
     end
 
-    defun start_link(_arg) :: {:ok, pid} do
+    defun start_link([]) :: {:ok, pid} do
       Supervisor.start_link([AntikytheraCore.ExecutorPool], [strategy: :simple_one_for_one, name: __MODULE__])
     end
   end

--- a/core/sup_tree_core/executor_pool/memcache_writer.ex
+++ b/core/sup_tree_core/executor_pool/memcache_writer.ex
@@ -15,7 +15,7 @@ defmodule AntikytheraCore.ExecutorPool.MemcacheWriter do
   alias AntikytheraCore.ExecutorPool.RegisteredName, as: RegName
   alias Antikythera.ExecutorPool.Id, as: EPoolId
 
-  def start_link(name, epool_id) do
+  def start_link([name, epool_id]) do
     GenServer.start_link(__MODULE__, epool_id, [name: name])
   end
 

--- a/core/sup_tree_core/executor_pool/timed_job_starter.ex
+++ b/core/sup_tree_core/executor_pool/timed_job_starter.ex
@@ -28,6 +28,13 @@ defmodule AntikytheraCore.ExecutorPool.TimedJobStarter do
   # (as long as there are available worker processes in the cluster).
   @interval 30_000
 
+  def child_spec(args) do
+    %{
+      id:    __MODULE__,
+      start: {__MODULE__, :start_link, args},
+    }
+  end
+
   defun start_link(queue_name :: v[atom], uploader_name :: v[atom | pid], epool_id :: v[EPoolId.t]) :: GenServer.on_start do
     GenServer.start_link(__MODULE__, {queue_name, uploader_name, epool_id})
   end

--- a/core/sup_tree_core/executor_pool/timed_job_starter.ex
+++ b/core/sup_tree_core/executor_pool/timed_job_starter.ex
@@ -28,14 +28,11 @@ defmodule AntikytheraCore.ExecutorPool.TimedJobStarter do
   # (as long as there are available worker processes in the cluster).
   @interval 30_000
 
-  def child_spec(args) do
-    %{
-      id:    __MODULE__,
-      start: {__MODULE__, :start_link, args},
-    }
+  def start_link([queue_name, uploader_name, epool_id]) do
+    start_link(queue_name, uploader_name, epool_id)
   end
 
-  defun start_link(queue_name :: v[atom], uploader_name :: v[atom | pid], epool_id :: v[EPoolId.t]) :: GenServer.on_start do
+  defunp start_link(queue_name :: v[atom], uploader_name :: v[atom | pid], epool_id :: v[EPoolId.t]) :: GenServer.on_start do
     GenServer.start_link(__MODULE__, {queue_name, uploader_name, epool_id})
   end
 

--- a/core/sup_tree_core/executor_pool/usage_reporter.ex
+++ b/core/sup_tree_core/executor_pool/usage_reporter.ex
@@ -24,7 +24,7 @@ defmodule AntikytheraCore.ExecutorPool.UsageReporter do
 
   @typep usage_rational :: {non_neg_integer, non_neg_integer}
 
-  def start_link(uploader_name, epool_id) do
+  def start_link([uploader_name, epool_id]) do
     GenServer.start_link(__MODULE__, {uploader_name, epool_id}, [])
   end
 

--- a/core/sup_tree_core/executor_pool/websocket_connections_counter.ex
+++ b/core/sup_tree_core/executor_pool/websocket_connections_counter.ex
@@ -15,14 +15,11 @@ defmodule AntikytheraCore.ExecutorPool.WebsocketConnectionsCounter do
   alias Antikythera.ExecutorPool.Id, as: EPoolId
   alias AntikytheraCore.ExecutorPool.RegisteredName, as: RegName
 
-  def child_spec(args) do
-    %{
-      id:    __MODULE__,
-      start: {__MODULE__, :start_link, args},
-    }
+  def start_link([max, name]) do
+    start_link(max, name)
   end
 
-  defun start_link(max :: v[non_neg_integer], name :: v[atom]) :: {:ok, pid} do
+  defunp start_link(max :: v[non_neg_integer], name :: v[atom]) :: {:ok, pid} do
     GenServer.start_link(__MODULE__, max, [name: name])
   end
 

--- a/core/sup_tree_core/executor_pool/websocket_connections_counter.ex
+++ b/core/sup_tree_core/executor_pool/websocket_connections_counter.ex
@@ -15,6 +15,13 @@ defmodule AntikytheraCore.ExecutorPool.WebsocketConnectionsCounter do
   alias Antikythera.ExecutorPool.Id, as: EPoolId
   alias AntikytheraCore.ExecutorPool.RegisteredName, as: RegName
 
+  def child_spec(args) do
+    %{
+      id:    __MODULE__,
+      start: {__MODULE__, :start_link, args},
+    }
+  end
+
   defun start_link(max :: v[non_neg_integer], name :: v[atom]) :: {:ok, pid} do
     GenServer.start_link(__MODULE__, max, [name: name])
   end

--- a/core/sup_tree_core/gear_config_poller.ex
+++ b/core/sup_tree_core/gear_config_poller.ex
@@ -24,7 +24,7 @@ defmodule AntikytheraCore.GearConfigPoller do
 
   @typep state_t :: %{last_checked_at: pos_integer}
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/gear_config_poller.ex
+++ b/core/sup_tree_core/gear_config_poller.ex
@@ -24,7 +24,7 @@ defmodule AntikytheraCore.GearConfigPoller do
 
   @typep state_t :: %{last_checked_at: pos_integer}
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/gear_executor_pools_manager.ex
+++ b/core/sup_tree_core/gear_executor_pools_manager.ex
@@ -20,7 +20,7 @@ defmodule AntikytheraCore.GearExecutorPoolsManager do
   @typep settings :: %{GearName.t => EPoolSetting.t}
   @typep state    :: %{gear_epool_settings: settings}
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/gear_executor_pools_manager.ex
+++ b/core/sup_tree_core/gear_executor_pools_manager.ex
@@ -20,7 +20,7 @@ defmodule AntikytheraCore.GearExecutorPoolsManager do
   @typep settings :: %{GearName.t => EPoolSetting.t}
   @typep state    :: %{gear_epool_settings: settings}
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/gear_manager.ex
+++ b/core/sup_tree_core/gear_manager.ex
@@ -13,7 +13,7 @@ defmodule AntikytheraCore.GearManager do
 
   @typep state_t :: %{GearName.t => nil}
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/gear_manager.ex
+++ b/core/sup_tree_core/gear_manager.ex
@@ -13,7 +13,7 @@ defmodule AntikytheraCore.GearManager do
 
   @typep state_t :: %{GearName.t => nil}
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/mnesia_nodes_cleaner.ex
+++ b/core/sup_tree_core/mnesia_nodes_cleaner.ex
@@ -25,7 +25,7 @@ defmodule AntikytheraCore.MnesiaNodesCleaner do
   alias AntikytheraCore.ClusterHostsPoller
   require AntikytheraCore.Logger, as: L
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/mnesia_nodes_cleaner.ex
+++ b/core/sup_tree_core/mnesia_nodes_cleaner.ex
@@ -25,7 +25,7 @@ defmodule AntikytheraCore.MnesiaNodesCleaner do
   alias AntikytheraCore.ClusterHostsPoller
   require AntikytheraCore.Logger, as: L
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/stale_gear_artifact_cleaner.ex
+++ b/core/sup_tree_core/stale_gear_artifact_cleaner.ex
@@ -21,7 +21,7 @@ defmodule AntikytheraCore.StaleGearArtifactCleaner do
 
   @interval (if Antikythera.Env.compile_env() == :local, do: 1_000, else: 24 * 60 * 60 * 1_000)
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/stale_gear_artifact_cleaner.ex
+++ b/core/sup_tree_core/stale_gear_artifact_cleaner.ex
@@ -21,7 +21,7 @@ defmodule AntikytheraCore.StaleGearArtifactCleaner do
 
   @interval (if Antikythera.Env.compile_env() == :local, do: 1_000, else: 24 * 60 * 60 * 1_000)
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/startup_manager.ex
+++ b/core/sup_tree_core/startup_manager.ex
@@ -26,7 +26,7 @@ defmodule AntikytheraCore.StartupManager do
   @typep step  :: :all_gears_installed
   @typep state :: %{step => boolean}
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/startup_manager.ex
+++ b/core/sup_tree_core/startup_manager.ex
@@ -26,7 +26,7 @@ defmodule AntikytheraCore.StartupManager do
   @typep step  :: :all_gears_installed
   @typep state :: %{step => boolean}
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/system_metrics_reporter.ex
+++ b/core/sup_tree_core/system_metrics_reporter.ex
@@ -23,7 +23,7 @@ defmodule AntikytheraCore.SystemMetricsReporter do
   @interval 300_000
   @typep metrics_t :: [{String.t, non_neg_integer}]
 
-  def start_link(uploader_name) do
+  def start_link([uploader_name]) do
     GenServer.start_link(__MODULE__, uploader_name, [])
   end
 

--- a/core/sup_tree_core/tenant_executor_pools_manager.ex
+++ b/core/sup_tree_core/tenant_executor_pools_manager.ex
@@ -50,7 +50,7 @@ defmodule AntikytheraCore.TenantExecutorPoolsManager do
   }
   @typep triplet :: {settings, [TenantId.t], %{TenantId.t => [GearName.t]}}
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/tenant_executor_pools_manager.ex
+++ b/core/sup_tree_core/tenant_executor_pools_manager.ex
@@ -50,7 +50,7 @@ defmodule AntikytheraCore.TenantExecutorPoolsManager do
   }
   @typep triplet :: {settings, [TenantId.t], %{TenantId.t => [GearName.t]}}
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/termination_manager.ex
+++ b/core/sup_tree_core/termination_manager.ex
@@ -52,7 +52,7 @@ defmodule AntikytheraCore.TerminationManager do
 
   @interval 180_000
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/termination_manager.ex
+++ b/core/sup_tree_core/termination_manager.ex
@@ -54,7 +54,7 @@ defmodule AntikytheraCore.TerminationManager do
 
   @interval 180_000
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/tmpdir_tracker.ex
+++ b/core/sup_tree_core/tmpdir_tracker.ex
@@ -30,7 +30,7 @@ defmodule AntikytheraCore.TmpdirTracker do
     ]
   end
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/tmpdir_tracker.ex
+++ b/core/sup_tree_core/tmpdir_tracker.ex
@@ -30,7 +30,7 @@ defmodule AntikytheraCore.TmpdirTracker do
     ]
   end
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/version_synchronizer.ex
+++ b/core/sup_tree_core/version_synchronizer.ex
@@ -17,7 +17,7 @@ defmodule AntikytheraCore.VersionSynchronizer do
   @start_wait_interval      500
   @version_monitor_interval (if Antikythera.Env.compile_env() == :local, do: 3_000, else: 60_000)
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/version_synchronizer.ex
+++ b/core/sup_tree_core/version_synchronizer.ex
@@ -17,7 +17,7 @@ defmodule AntikytheraCore.VersionSynchronizer do
   @start_wait_interval      500
   @version_monitor_interval (if Antikythera.Env.compile_env() == :local, do: 3_000, else: 60_000)
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok)
   end
 

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -15,7 +15,7 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
   alias Antikythera.GearName
   alias AntikytheraCore.Version
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_core/version_upgrade_task_queue.ex
+++ b/core/sup_tree_core/version_upgrade_task_queue.ex
@@ -16,7 +16,7 @@ defmodule AntikytheraCore.VersionUpgradeTaskQueue do
   alias AntikytheraCore.Version
   require AntikytheraCore.Logger, as: L
 
-  def start_link(_args) do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 

--- a/core/sup_tree_gear/gear_log_writer.ex
+++ b/core/sup_tree_gear/gear_log_writer.ex
@@ -31,7 +31,7 @@ defmodule AntikytheraCore.GearLog.Writer do
     ]
   end
 
-  def start_link(gear_name, logger_name) do
+  def start_link([gear_name, logger_name]) do
     opts = if logger_name, do: [name: logger_name], else: []
     %GearConfig{log_level: min_level} = ConfigCache.Gear.read(gear_name)
     GenServer.start_link(__MODULE__, {gear_name, min_level}, opts)

--- a/lib/gear_application/gear_application.ex
+++ b/lib/gear_application/gear_application.ex
@@ -27,10 +27,10 @@ defmodule Antikythera.GearApplication do
   alias AntikytheraCore.Config.Gear, as: GearConfig
   alias AntikytheraCore.GearLog.Writer
 
-  @type child_spec :: [:supervisor.child_spec | {module, term} | module]
+  @type child_spec :: :supervisor.child_spec | {module, term} | module
 
   @doc false
-  defun start(gear_name :: v[GearName.t], children :: child_spec) :: {:ok, pid} do
+  defun start(gear_name :: v[GearName.t], children :: [child_spec]) :: {:ok, pid} do
     GearConfig.ensure_loaded(gear_name)
     all_children = predefined_children(gear_name) ++ children
     opts = [
@@ -43,7 +43,7 @@ defmodule Antikythera.GearApplication do
     {:ok, pid}
   end
 
-  defunp predefined_children(gear_name :: v[GearName.t]) :: child_spec do
+  defunp predefined_children(gear_name :: v[GearName.t]) :: [child_spec] do
     # In many cases the process name atoms below are already generated (as module names) at compile-time in `__using__/1` macro.
     # However we don't assume that all these atoms actually exist and thus use unsafe functions,
     # in order to handle gears' beam files compiled with an older version of antikythera
@@ -64,7 +64,7 @@ defmodule Antikythera.GearApplication do
     ExecutorPool.kill_executor_pool({:gear, gear_name})
   end
 
-  @callback children()                            :: child_spec
+  @callback children()                            :: [child_spec]
   @callback executor_pool_for_web_request(Conn.t) :: EPoolId.t
 
   defmacro __using__(_) do

--- a/lib/gear_application/gear_application.ex
+++ b/lib/gear_application/gear_application.ex
@@ -27,8 +27,10 @@ defmodule Antikythera.GearApplication do
   alias AntikytheraCore.Config.Gear, as: GearConfig
   alias AntikytheraCore.GearLog.Writer
 
+  @type child_spec :: [:supervisor.child_spec | {module, term} | module]
+
   @doc false
-  defun start(gear_name :: v[GearName.t], children :: list) :: {:ok, pid} do
+  defun start(gear_name :: v[GearName.t], children :: child_spec) :: {:ok, pid} do
     GearConfig.ensure_loaded(gear_name)
     all_children = predefined_children(gear_name) ++ children
     opts = [
@@ -41,7 +43,7 @@ defmodule Antikythera.GearApplication do
     {:ok, pid}
   end
 
-  defunp predefined_children(gear_name :: v[GearName.t]) :: list do
+  defunp predefined_children(gear_name :: v[GearName.t]) :: child_spec do
     # In many cases the process name atoms below are already generated (as module names) at compile-time in `__using__/1` macro.
     # However we don't assume that all these atoms actually exist and thus use unsafe functions,
     # in order to handle gears' beam files compiled with an older version of antikythera
@@ -62,7 +64,7 @@ defmodule Antikythera.GearApplication do
     ExecutorPool.kill_executor_pool({:gear, gear_name})
   end
 
-  @callback children()                            :: list
+  @callback children()                            :: child_spec
   @callback executor_pool_for_web_request(Conn.t) :: EPoolId.t
 
   defmacro __using__(_) do

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule Antikythera.Mixfile do
       {:cowlib      , "2.1.0" , [antikythera_internal: true]},
       {:hackney     , "1.9.0" , [antikythera_internal: true]},
       {:calliope    , "0.4.1" , [antikythera_internal: true]}, # 0.4.2 is broken!
-      {:pool_sup    , "0.4.0" , [antikythera_internal: true]},
+      {:pool_sup    , "0.5.0" , [antikythera_internal: true]},
       {:raft_fleet  , "0.8.2" , [antikythera_internal: true]},
       {:rafted_value, "0.9.2" , [antikythera_internal: true]},
       {:syn         , "1.6.3" , [antikythera_internal: true]},

--- a/mix.lock
+++ b/mix.lock
@@ -31,7 +31,7 @@
   "p1_utils": {:hex, :p1_utils, "1.0.11", "a471f80644d4b464fa67572affddda7e95df5d4b099624b8907f5726e8a1769c", [:rebar3], [], "hexpm"},
   "pbkdf2": {:hex, :pbkdf2, "2.0.0", "11c23279fded5c0027ab3996cfae77805521d7ef4babde2bd7ec04a9086cf499", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
-  "pool_sup": {:hex, :pool_sup, "0.4.0", "c3e62f796600aadbd7306f95bb90479660063446c7e7cc75232d9c106f687bed", [:mix], [{:croma, "~> 0.7", [hex: :croma, repo: "hexpm", optional: false]}], "hexpm"},
+  "pool_sup": {:hex, :pool_sup, "0.5.0", "79c0a7746ee861627fe1fa89073317f7803707f6b20250a436b54a65d13009e5", [:mix], [{:croma, "~> 0.9", [hex: :croma, repo: "hexpm", optional: false]}], "hexpm"},
   "providers": {:hex, :providers, "1.6.0", "db0e2f9043ae60c0155205fcd238d68516331d0e5146155e33d1e79dc452964a", [:rebar3], [{:getopt, "0.8.2", [hex: :getopt, repo: "hexpm", optional: false]}], "hexpm"},
   "raft_fleet": {:hex, :raft_fleet, "0.8.2", "4c7fc54c36979aad224f00bd4fed3283cd02230e1849746863800dfb5db69f4b", [:mix], [{:croma, "~> 0.7", [hex: :croma, repo: "hexpm", optional: false]}, {:rafted_value, "~> 0.8", [hex: :rafted_value, repo: "hexpm", optional: false]}], "hexpm"},
   "rafted_value": {:hex, :rafted_value, "0.9.2", "7cbc3b161f5e62a2cd91d32efe83e1431d7c77a8a878b23888f03d57ca30733e", [:mix], [{:croma, "~> 0.7", [hex: :croma, repo: "hexpm", optional: false]}], "hexpm"},

--- a/priv/gear_template/lib/gear_name.ex
+++ b/priv/gear_template/lib/gear_name.ex
@@ -2,7 +2,7 @@ defmodule <%= gear_name_camel %> do
   use Antikythera.GearApplication
   alias Antikythera.{ExecutorPool, Conn}
 
-  @spec children :: [Supervisor.Spec.spec]
+  @spec children :: list
   def children() do
     [
       # gear-specific workers/supervisors

--- a/priv/gear_template/lib/gear_name.ex
+++ b/priv/gear_template/lib/gear_name.ex
@@ -2,9 +2,9 @@ defmodule <%= gear_name_camel %> do
   use Antikythera.GearApplication
   alias Antikythera.{ExecutorPool, Conn}
 
-  @type child_spec :: [:supervisor.child_spec | {module, term} | module]
+  @type child_spec :: :supervisor.child_spec | {module, term} | module
 
-  @spec children :: child_spec
+  @spec children :: [child_spec]
   def children() do
     [
       # gear-specific workers/supervisors

--- a/priv/gear_template/lib/gear_name.ex
+++ b/priv/gear_template/lib/gear_name.ex
@@ -2,7 +2,9 @@ defmodule <%= gear_name_camel %> do
   use Antikythera.GearApplication
   alias Antikythera.{ExecutorPool, Conn}
 
-  @spec children :: list
+  @type child_spec :: [:supervisor.child_spec | {module, term} | module]
+
+  @spec children :: child_spec
   def children() do
     [
       # gear-specific workers/supervisors

--- a/test/core/sup_tree_common/metrics_uploader_test.exs
+++ b/test/core/sup_tree_common/metrics_uploader_test.exs
@@ -79,7 +79,7 @@ defmodule AntikytheraCore.MetricsUploaderTest do
     t1 = Time.truncate_to_minute(Time.now())
     t2 = Time.shift_minutes(t1, 1)
     assert Storage.Memory.download(:testgear, epool_id, t1, t2) == []
-    {:ok, pid} = U.start_link(:testgear, Testgear.MetricsUploader)
+    {:ok, pid} = U.start_link([:testgear, Testgear.MetricsUploader])
     U.submit(pid, [{"metrics1", :average, 5.0}], epool_id)
     :ok = GenServer.stop(pid)
     [{_time, data}] = Storage.Memory.download(:testgear, epool_id, t1, t2)

--- a/test/core/sup_tree_core/system_metrics_reporter_test.exs
+++ b/test/core/sup_tree_core/system_metrics_reporter_test.exs
@@ -7,7 +7,7 @@ defmodule AntikytheraCore.SystemMetricsReporterTest do
   alias AntikytheraCore.Metrics.AggregateStrategy.Gauge
 
   setup do
-    {:ok, pid} = SystemMetricsReporter.start_link(self()) # will be killed together with `self` when each test is completed
+    {:ok, pid} = SystemMetricsReporter.start_link([self()]) # will be killed together with `self` when each test is completed
     {:ok, [pid: pid]}
   end
 

--- a/test/core/sup_tree_gear/gear_log_writer_test.exs
+++ b/test/core/sup_tree_gear/gear_log_writer_test.exs
@@ -49,7 +49,7 @@ defmodule AntikytheraCore.GearLog.WriterTest do
 
   setup do
     clean()
-    {:ok, pid} = Writer.start_link(:testgear, @logger_name)
+    {:ok, pid} = Writer.start_link([:testgear, @logger_name])
     on_exit(&clean/0)
     {:ok, [pid: pid]}
   end
@@ -62,7 +62,7 @@ defmodule AntikytheraCore.GearLog.WriterTest do
     assert_empty?(pid1, false)
     :ok = GenServer.stop(pid1)
 
-    {:ok, pid2} = Writer.start_link(:testgear, @logger_name)
+    {:ok, pid2} = Writer.start_link([:testgear, @logger_name])
     assert_content_of_rotated("message 1")
     GenServer.stop(pid2)
   end


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/133886
* Changed to use ["Streamlined child specs"](https://elixir-lang.org/blog/2017/07/25/elixir-v1-5-0-released/#streamlined-child-specs) bacause `Supervisor.Spec` is deprecated.