### PR TITLE
[157910] Cap `ws_max_connections` in gear/tenant exec pool settings based on available system memory

### DIFF
--- a/core/config/core.ex
+++ b/core/config/core.ex
@@ -56,7 +56,7 @@ defmodule AntikytheraCore.Config.Core do
   @doc """
   Writes a map to antikythera's config file.
 
-  Currently this function is never called in the repository; it's to be used within remote_console.
+  Currently this function is intended to be used within remote_console.
   """
   defun write(config :: v[map]) :: :ok do
     path = CorePath.core_config_file_path()

--- a/core/ets/system_cache.ex
+++ b/core/ets/system_cache.ex
@@ -8,6 +8,7 @@ defmodule AntikytheraCore.Ets.SystemCache do
     AntikytheraCore.Cluster.NodeId.init()
     AntikytheraCore.Config.EncryptionKey.init()
     AntikytheraCore.Handler.SystemInfoExporter.AccessToken.init()
+    AntikytheraCore.OsUtil.init()
   end
 
   defun table_name() :: atom do

--- a/core/executor_pool/setting.ex
+++ b/core/executor_pool/setting.ex
@@ -5,6 +5,7 @@ use Croma
 defmodule AntikytheraCore.ExecutorPool.Setting do
   alias Antikythera.{MapUtil, GearName}
   alias AntikytheraCore.Ets.ConfigCache
+  alias AntikytheraCore.ExecutorPool.WsConnectionsCapping
 
   use Croma.Struct, recursive_new?: true, fields: [
     n_pools_a:          Croma.NonNegInteger,
@@ -31,6 +32,7 @@ defmodule AntikytheraCore.ExecutorPool.Setting do
     |> Map.get(:gears, %{})
     |> MapUtil.map_values(fn {_, map} ->
       Map.merge(@default, Map.get(map, :executor_pool, %{}))
+      |> WsConnectionsCapping.cap_based_on_available_memory()
     end)
   end
 end

--- a/core/executor_pool/tenant_setting.ex
+++ b/core/executor_pool/tenant_setting.ex
@@ -7,6 +7,7 @@ defmodule AntikytheraCore.ExecutorPool.TenantSetting do
   alias Antikythera.{GearName, TenantId, SecondsSinceEpoch}
   alias AntikytheraCore.Path, as: CorePath
   alias AntikytheraCore.ExecutorPool.Setting, as: EPoolSetting
+  alias AntikytheraCore.ExecutorPool.WsConnectionsCapping
   alias AntikytheraCore.TenantExecutorPoolsManager
   require AntikytheraCore.Logger, as: L
 
@@ -48,7 +49,8 @@ defmodule AntikytheraCore.ExecutorPool.TenantSetting do
       replaced1  =  Map.put(parsed, "gears", gear_names)
       replaced2  =  Map.put_new(replaced1, "ws_max_connections", 100) # fill the default value to migrate from JSON without "ws_max_connections" to JSON with the field
       tsetting   <- new(replaced2)
-      pure {tenant_id, tsetting}
+      capped     =  WsConnectionsCapping.cap_based_on_available_memory(tsetting)
+      pure {tenant_id, capped}
     end
     |> case do
       {:ok, pair}       -> pair

--- a/core/executor_pool/ws_connections_capping.ex
+++ b/core/executor_pool/ws_connections_capping.ex
@@ -1,0 +1,23 @@
+# Copyright(c) 2015-2018 ACCESS CO., LTD. All rights reserved.
+
+use Croma
+
+defmodule AntikytheraCore.ExecutorPool.WsConnectionsCapping do
+  alias AntikytheraCore.OsUtil
+  alias AntikytheraCore.ExecutorPool.{Setting, TenantSetting}
+
+  # The following constants are heuristic values, not rigorous ones.
+  # (Should we make them mix config items?)
+  @ratio_of_max_memory_occupation_by_ws_connections_in_1_epool 0.5
+  @ws_connections_per_megabytes                                10
+
+  defun cap_based_on_available_memory(setting :: setting) :: setting when setting: Setting.t | TenantSetting.t do
+    connections = min(setting.ws_max_connections, upper_limit())
+    %{setting | ws_max_connections: connections}
+  end
+
+  defpt upper_limit() do
+    usable_bytes = trunc(OsUtil.total_memory_size_in_bytes() * @ratio_of_max_memory_occupation_by_ws_connections_in_1_epool)
+    div(usable_bytes, 1_000_000) * @ws_connections_per_megabytes
+  end
+end

--- a/core/sup_tree_core/core_config_poller.ex
+++ b/core/sup_tree_core/core_config_poller.ex
@@ -14,7 +14,7 @@ defmodule AntikytheraCore.CoreConfigPoller do
   @interval 120_000
 
   def start_link([]) do
-    GenServer.start_link(__MODULE__, :ok, [])
+    GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
   end
 
   @impl true

--- a/core/util/os_util.ex
+++ b/core/util/os_util.ex
@@ -1,0 +1,36 @@
+# Copyright(c) 2015-2018 ACCESS CO., LTD. All rights reserved.
+
+use Croma
+
+defmodule AntikytheraCore.OsUtil do
+  alias AntikytheraCore.Ets.SystemCache
+
+  defun init() :: :ok do
+    :ets.insert(SystemCache.table_name(), {:total_memory_size_in_bytes, get_total_memory_size_in_bytes()})
+    :ok
+  end
+
+  defun total_memory_size_in_bytes() :: pos_integer do
+    [{_, bytes}] = :ets.lookup(SystemCache.table_name(), :total_memory_size_in_bytes)
+    bytes
+  end
+
+  defunp get_total_memory_size_in_bytes() :: pos_integer do
+    case :os.type() do
+      {:unix, :linux}  -> total_memory_size_linux()
+      {:unix, :darwin} -> total_memory_size_darwin()
+    end
+  end
+
+  defp total_memory_size_linux() do
+    {output, 0} = System.cmd("free", ["-b"])
+    [_, l | _] = String.split(output, "\n")
+    [_, n | _] = String.split(l)
+    String.to_integer(n)
+  end
+
+  defp total_memory_size_darwin() do
+    {output, 0} = System.cmd("sysctl", ["-n", "hw.memsize"])
+    String.trim_trailing(output) |> String.to_integer()
+  end
+end

--- a/test/core/executor_pool/setting_test.exs
+++ b/test/core/executor_pool/setting_test.exs
@@ -1,0 +1,31 @@
+# Copyright(c) 2015-2018 ACCESS CO., LTD. All rights reserved.
+
+defmodule AntikytheraCore.ExecutorPool.SettingTest do
+  use Croma.TestCase
+  alias Antikythera.Test.GenServerHelper
+  alias AntikytheraCore.Config.Core, as: CoreConfig
+  alias AntikytheraCore.Ets.ConfigCache.Core, as: CoreConfigCache
+  alias AntikytheraCore.CoreConfigPoller
+  alias AntikytheraCore.ExecutorPool.WsConnectionsCapping
+
+  defp with_modified_core_config(conf, f) do
+    orig = CoreConfigCache.read()
+    CoreConfig.write(conf)
+    GenServerHelper.send_message_and_wait(CoreConfigPoller, :timeout)
+    try do
+      f.()
+    after
+      CoreConfig.write(orig)
+      GenServerHelper.send_message_and_wait(CoreConfigPoller, :timeout)
+    end
+  end
+
+  test "should cap ws_max_connections based on available memory" do
+    limit = WsConnectionsCapping.upper_limit()
+    conf = %{gears: %{testgear: %{executor_pool: %{ws_max_connections: limit + 1}}}}
+    with_modified_core_config(conf, fn ->
+      s = Setting.of_gear(:testgear)
+      assert s.ws_max_connections == limit
+    end)
+  end
+end


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/157910