### PR TITLE
[177185] Wrapper library for zip

### DIFF
--- a/core/sup_tree_core/tmpdir_tracker.ex
+++ b/core/sup_tree_core/tmpdir_tracker.ex
@@ -54,7 +54,7 @@ defmodule AntikytheraCore.TmpdirTracker do
   @impl true
   def handle_call({:get, pid, epool_id}, _from, %State{map: map} = state) do
     case Map.get(map, pid) do
-      nil -> {:reply, {:error, {:not_found, %{state: state}}}, state}
+      nil -> {:reply, {:error, :not_found}, state}
       _   -> {:reply, {:ok, tmpdir_path(state, pid, epool_id)}, state}
     end
   end

--- a/core/sup_tree_core/tmpdir_tracker.ex
+++ b/core/sup_tree_core/tmpdir_tracker.ex
@@ -51,6 +51,14 @@ defmodule AntikytheraCore.TmpdirTracker do
     end
   end
 
+  @impl true
+  def handle_call({:get, pid, epool_id}, _from, %State{map: map} = state) do
+    case Map.get(map, pid) do
+      nil -> {:reply, {:error, {:not_found, %{state: state}}}, state}
+      _   -> {:reply, {:ok, tmpdir_path(state, pid, epool_id)}, state}
+    end
+  end
+
   defp tmpdir_path(%State{gear_tmp_dir: gear_tmp_dir}, pid, epool_id) do
     Path.join([gear_tmp_dir, EPoolId.to_string(epool_id), Integer.to_string(:erlang.phash2(pid))])
   end
@@ -86,6 +94,10 @@ defmodule AntikytheraCore.TmpdirTracker do
       File.mkdir_p!(tmpdir)
       tmpdir
     end)
+  end
+
+  defun get(epool_id :: v[EPoolId.t]) :: R.t(Path.t) do
+    GenServer.call(__MODULE__, {:get, self(), epool_id})
   end
 
   defun finished() :: :ok do

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -19,7 +19,7 @@ defmodule Antikythera.Zip do
   @typep opts :: {:encryption, boolean} | {:password, String.t}
 
   defmodule FileName do
-    use Croma.SubtypeOfString, pattern: ~r/^(?!.*\/\.{0,2}\z).*\z/
+    use Croma.SubtypeOfString, pattern: ~R/^(?!.*\/\.{0,2}\z).*\z/
   end
 
   @doc """

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -51,8 +51,8 @@ defmodule Antikythera.Zip do
       src_path      <- Path.expand(src_raw_path),
       :ok           <- validate_within_tmpdir(zip_path, tmpdir),
       :ok           <- validate_within_tmpdir(src_path, tmpdir),
-      :ok           <- ensure_path_exists(zip_path, tmpdir),
       :ok           <- validate_path_exists(src_path),
+      :ok           <- ensure_path_exists(zip_path, tmpdir),
       {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
       :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
     ) do
@@ -84,6 +84,14 @@ defmodule Antikythera.Zip do
     end
   end
 
+  defunp validate_path_exists(path :: v[String.t]) :: :ok | {:error, tuple} do
+    if File.exists?(path) do
+      :ok
+    else
+      {:error, {:not_found, %{path: path}}}
+    end
+  end
+
   defunp ensure_path_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
     path
     |> Path.dirname()
@@ -96,14 +104,6 @@ defmodule Antikythera.Zip do
     end)
     File.touch!(path)
     :ok
-  end
-
-  defunp validate_path_exists(path :: v[String.t]) :: :ok | {:error, tuple} do
-    if File.exists?(path) do
-      :ok
-    else
-      {:error, {:not_found, %{path: path}}}
-    end
   end
 
   defunp extract_zip_args(map :: map) :: R.t(list(String.t)) do

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -52,7 +52,7 @@ defmodule Antikythera.Zip do
       :ok           <- validate_within_tmpdir(zip_path, tmpdir),
       :ok           <- validate_within_tmpdir(src_path, tmpdir),
       :ok           <- validate_path_exists(src_path),
-      :ok           <- ensure_path_exists(zip_path, tmpdir),
+      :ok           <- ensure_dir_exists(zip_path, tmpdir),
       {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
       :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
     ) do
@@ -92,7 +92,7 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp ensure_path_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
+  defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
     path
     |> Path.dirname()
     |> String.trim_leading(tmpdir <> "/")
@@ -102,7 +102,6 @@ defmodule Antikythera.Zip do
       File.mkdir_p!(child)
       child
     end)
-    File.touch!(path)
     :ok
   end
 

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -47,8 +47,7 @@ defmodule Antikythera.Zip do
       {:ok, tmpdir} <- TmpdirTracker.get(epool_id),
       :ok           <- validate_within_tmpdir(zip_path, tmpdir),
       :ok           <- validate_within_tmpdir(src_path, tmpdir),
-      :ok           <- validate_path_exists(zip_path, false),
-      :ok           <- validate_path_exists(src_path, true),
+      :ok           <- validate_path_exists(src_path),
       {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
       :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
     ) do
@@ -67,14 +66,11 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp validate_path_exists(path :: v[String.t], exists? :: v[boolean]) :: :ok | {:error, tuple} do
-    case File.exists?(path) do
-      ^exists? ->
-        :ok
-      true     ->
-        {:error, {:already_exists, %{path: path}}}
-      false    ->
-        {:error, {:not_found,      %{path: path}}}
+  defunp validate_path_exists(path :: v[String.t]) :: :ok | {:error, tuple} do
+    if path |> Path.expand() |> File.exists?() do
+      :ok
+    else
+      {:error, {:not_found, %{path: path}}}
     end
   end
 

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -90,19 +90,13 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
+  defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok | {:error, tuple} do
     dirname = Path.dirname(path)
     if dirname != tmpdir do
-      dirname
-      |> String.trim_leading(tmpdir <> "/")
-      |> String.split("/")
-      |> Enum.reduce(tmpdir, fn (x, acc) ->
-        child = acc <> "/" <> x
-        File.mkdir_p!(child)
-        child
-      end)
+      File.mkdir_p(dirname)
+    else
+      :ok
     end
-    :ok
   end
 
   defunp extract_zip_args(map :: map) :: R.t(list(String.t)) do

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -19,7 +19,7 @@ defmodule Antikythera.Zip do
   @typep opts :: {:encryption, boolean} | {:password, String.t}
 
   defmodule FileName do
-    use Croma.SubtypeOfString, pattern: ~r/[^(\/\.{0,2})]\z/
+    use Croma.SubtypeOfString, pattern: ~r/^(?!.*\/\.{0,2}\z).*\z/
   end
 
   @doc """

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -49,8 +49,8 @@ defmodule Antikythera.Zip do
       :ok           <- validate_path_type(src_path, [:file, :dir]),
       :ok           <- validate_within_tmpdir(zip_path, tmpdir),
       :ok           <- validate_within_tmpdir(src_path, tmpdir),
-      :ok           <- ensure_zip_dir(zip_path, tmpdir),
-      :ok           <- validate_path_exists(src_path),
+      :ok           <- ensure_dir_exists(zip_path, tmpdir),
+      :ok           <- ensure_path_exists(src_path),
       {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
       :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
     ) do
@@ -88,7 +88,7 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp ensure_zip_dir(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
+  defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
     path
     |> Path.dirname()
     |> String.trim_leading(tmpdir <> "/")
@@ -101,7 +101,7 @@ defmodule Antikythera.Zip do
     :ok
   end
 
-  defunp validate_path_exists(path :: v[String.t]) :: :ok | {:error, tuple} do
+  defunp ensure_path_exists(path :: v[String.t]) :: :ok | {:error, tuple} do
     if path |> Path.expand() |> File.exists?() do
       :ok
     else

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -18,6 +18,24 @@ defmodule Antikythera.Zip do
 
   @typep opts :: {:encryption, boolean} | {:password, String.t}
 
+  @doc """
+  Creates a ZIP file.
+
+  Encryption using a password is supported in which `encryption` option is set `true`.
+
+  ## Example
+    Tmpdir.make(context, fn tmpdir ->
+      src_path = tmpdir <> "/src.txt"
+      zip_path = tmpdir <> "/archive.zip"
+      File.write!(src_path, "text")
+      Antikythera.Zip.zip(context, zip_path, src_path, [encryption: true, password: "password"])
+      |> case do
+        {:ok, archive_path} ->
+          ...
+      end
+      ...
+    end)
+  """
   defun zip(
     context_or_epool_id :: v[EPoolId.t | Context.t],
     zip_path            :: v[String.t],

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -16,7 +16,7 @@ defmodule Antikythera.Zip do
     epool_id = extract_epool_id(context_or_epool_id)
     with(
       {:ok, tmpdir} <- TmpdirTracker.get(epool_id),
-      {_,   0}      <- try_zip_cmd([zip_path, src_path])
+      :ok           <- try_zip_cmd([zip_path, src_path])
     ) do
       {:ok, zip_path}
     end
@@ -24,4 +24,13 @@ defmodule Antikythera.Zip do
 
   defp extract_epool_id(%Context{executor_pool_id: epool_id}), do: epool_id
   defp extract_epool_id(epool_id),                             do: epool_id
+
+  defunp try_zip_cmd(args :: v[list(String.t)]) :: :ok | {:error, tuple} do
+    case System.cmd("zip", args) do
+      {_,   0}      ->
+        :ok
+      {msg, status} ->
+        {:error, {:shell_runtime_error, %{msg: msg, status: status}}}
+    end
+  end
 end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -121,18 +121,18 @@ defmodule Antikythera.Zip do
         {:ok,    ["-P", password]}
       %{encryption: true} ->
         {:error, {:argument_error, map}}
-      %{encryption: false, password: _}        ->
+      %{encryption: false, password: _} ->
         {:error, {:argument_error, map}}
-      _                                        ->
+      _ ->
         {:ok,    []}
     end
   end
 
   defunp try_zip_cmd(args :: v[list(String.t)]) :: :ok | {:error, :shell_runtime_error} do
     case System.cmd("zip", args) do
-      {_,   0} ->
+      {_, 0} ->
         :ok
-      _        ->
+      _ ->
         {:error, :shell_runtime_error}
     end
   end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -91,15 +91,17 @@ defmodule Antikythera.Zip do
   end
 
   defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
-    path
-    |> Path.dirname()
-    |> String.trim_leading(tmpdir <> "/")
-    |> String.split("/")
-    |> Enum.reduce(tmpdir, fn (x, acc) ->
-      child = acc <> "/" <> x
-      File.mkdir_p!(child)
-      child
-    end)
+    dirname = Path.dirname(path)
+    if dirname != tmpdir do
+      dirname
+      |> String.trim_leading(tmpdir <> "/")
+      |> String.split("/")
+      |> Enum.reduce(tmpdir, fn (x, acc) ->
+        child = acc <> "/" <> x
+        File.mkdir_p!(child)
+        child
+      end)
+    end
     :ok
   end
 

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -8,10 +8,13 @@ defmodule Antikythera.Zip do
   alias Antikythera.ExecutorPool.Id, as: EPoolId
   alias AntikytheraCore.TmpdirTracker
 
+  @typep opts :: {:encryption, boolean} | {:password, String.t}
+
   defun zip(
     context_or_epool_id :: v[EPoolId.t | Context.t],
     zip_path            :: v[String.t],
-    src_path            :: v[String.t]
+    src_path            :: v[String.t],
+    _opts               :: v[list(opts)] \\ []
   ) :: R.t(Path.t) do
     epool_id = extract_epool_id(context_or_epool_id)
     with(

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -3,6 +3,14 @@
 use Croma
 
 defmodule Antikythera.Zip do
+  @moduledoc """
+  Wrapper module for `zip` command.
+
+  For the consistency in working with antikythera and other gears, scope of this module is limited under a temporary directory reserved by `Antikythera.Tmpdir.make/2`.
+
+  Functions only accept absolute paths for both source and resulting archive.
+  """
+
   alias Croma.Result, as: R
   alias Antikythera.Context
   alias Antikythera.ExecutorPool.Id, as: EPoolId

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -40,26 +40,22 @@ defmodule Antikythera.Zip do
       ...
     end)
   """
-  defun zip(
-    context_or_epool_id :: v[EPoolId.t | Context.t],
-    zip_raw_path        :: v[FileName.t],
-    src_raw_path        :: v[String.t],
-    opts                :: v[list(opts)] \\ []
-  ) :: R.t(Path.t) do
+  defun zip(context_or_epool_id :: v[EPoolId.t | Context.t],
+            zip_raw_path        :: v[FileName.t],
+            src_raw_path        :: v[String.t],
+            opts                :: v[list(opts)] \\ []) :: R.t(Path.t) do
     epool_id = extract_epool_id(context_or_epool_id)
-    with(
-      {:ok, tmpdir} <- TmpdirTracker.get(epool_id),
-      :ok           <- reject_existing_dir(zip_raw_path),
-      :ok           <- validate_suffix(src_raw_path),
-      zip_path      <- Path.expand(zip_raw_path),
-      src_path      <- Path.expand(src_raw_path),
-      :ok           <- validate_within_tmpdir(zip_path, tmpdir),
-      :ok           <- validate_within_tmpdir(src_path, tmpdir),
-      :ok           <- validate_path_exists(src_path),
-      :ok           <- ensure_dir_exists(zip_path, tmpdir),
-      {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
-      :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
-    ) do
+    with {:ok, tmpdir} <- TmpdirTracker.get(epool_id),
+         :ok           <- reject_existing_dir(zip_raw_path),
+         :ok           <- validate_suffix(src_raw_path),
+         zip_path      <- Path.expand(zip_raw_path),
+         src_path      <- Path.expand(src_raw_path),
+         :ok           <- validate_within_tmpdir(zip_path, tmpdir),
+         :ok           <- validate_within_tmpdir(src_path, tmpdir),
+         :ok           <- validate_path_exists(src_path),
+         :ok           <- ensure_dir_exists(zip_path, tmpdir),
+         {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
+         :ok           <- try_zip_cmd(args ++ [zip_path, src_path]) do
       if zip_path |> Path.basename() |> String.contains?(".") do
         {:ok, zip_path}
       else

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -1,0 +1,15 @@
+# Copyright(c) 2015-2019 ACCESS CO., LTD. All rights reserved.
+
+use Croma
+
+defmodule Antikythera.Zip do
+  alias Croma.Result, as: R
+
+  defun zip(
+    zip_path :: v[String.t],
+    src_path :: v[String.t]
+  ) :: R.t(Path.t) do
+    {_, 0} = System.cmd("zip", [zip_path, src_path])
+    {:ok, zip_path}
+  end
+end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -115,8 +115,12 @@ defmodule Antikythera.Zip do
 
   defunp extract_zip_args(map :: map) :: R.t(list(String.t)) do
     case map do
+      %{password: ""} ->
+        {:error, {:argument_error, map}}
       %{encryption: true,  password: password} ->
         {:ok,    ["-P", password]}
+      %{encryption: true} ->
+        {:error, {:argument_error, map}}
       %{encryption: false, password: _}        ->
         {:error, {:argument_error, map}}
       _                                        ->

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -19,7 +19,7 @@ defmodule Antikythera.Zip do
   @typep opts :: {:encryption, boolean} | {:password, String.t}
 
   defmodule FileName do
-    use Croma.SubtypeOfString, pattern: ~r/[^\/]\z/
+    use Croma.SubtypeOfString, pattern: ~r/[^\/]\.{0,2}\z/
   end
 
   @doc """

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -93,7 +93,12 @@ defmodule Antikythera.Zip do
   defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok | {:error, tuple} do
     dirname = Path.dirname(path)
     if dirname != tmpdir do
-      File.mkdir_p(dirname)
+      case File.mkdir_p(dirname) do
+        :ok ->
+          :ok
+        {:error, :eexist} ->
+          {:error, {:not_dir, %{path: path}}}
+      end
     else
       :ok
     end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -92,6 +92,7 @@ defmodule Antikythera.Zip do
       File.mkdir_p!(child)
       child
     end)
+    File.touch!(path)
     :ok
   end
 

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -124,12 +124,12 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp try_zip_cmd(args :: v[list(String.t)]) :: :ok | {:error, tuple} do
+  defunp try_zip_cmd(args :: v[list(String.t)]) :: :ok | {:error, :shell_runtime_error} do
     case System.cmd("zip", args) do
-      {_,   0}      ->
+      {_,   0} ->
         :ok
-      {msg, status} ->
-        {:error, {:shell_runtime_error, %{msg: msg, status: status}}}
+      _        ->
+        {:error, :shell_runtime_error}
     end
   end
 end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -60,7 +60,11 @@ defmodule Antikythera.Zip do
       {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
       :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
     ) do
-      {:ok, zip_path}
+      if zip_path |> Path.basename() |> String.contains?(".") do
+        {:ok, zip_path}
+      else
+        {:ok, zip_path <> ".zip"}
+      end
     end
   end
 

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -21,6 +21,8 @@ defmodule Antikythera.Zip do
       {:ok, tmpdir} <- TmpdirTracker.get(epool_id),
       :ok           <- validate_within_tmpdir(zip_path, tmpdir),
       :ok           <- validate_within_tmpdir(src_path, tmpdir),
+      :ok           <- validate_path_exists(zip_path, false),
+      :ok           <- validate_path_exists(src_path, true),
       {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
       :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
     ) do
@@ -36,6 +38,17 @@ defmodule Antikythera.Zip do
       :ok
     else
       {:error, {:permission_denied, %{path: path, tmpdir: tmpdir}}}
+    end
+  end
+
+  defunp validate_path_exists(path :: v[String.t], exists? :: v[boolean]) :: :ok | {:error, tuple} do
+    case File.exists?(path) do
+      ^exists? ->
+        :ok
+      true     ->
+        {:error, {:already_exists, %{path: path}}}
+      false    ->
+        {:error, {:not_found,      %{path: path}}}
     end
   end
 

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -19,7 +19,7 @@ defmodule Antikythera.Zip do
   @typep opts :: {:encryption, boolean} | {:password, String.t}
 
   defmodule FileName do
-    use Croma.SubtypeOfString, pattern: ~r/[^\/]\.{0,2}\z/
+    use Croma.SubtypeOfString, pattern: ~r/[^(\/\.{0,2})]\z/
   end
 
   @doc """

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -33,6 +33,8 @@ defmodule Antikythera.Zip do
     case map do
       %{encryption: true,  password: password} ->
         {:ok,    ["-P", password]}
+      %{encryption: false, password: _}        ->
+        {:error, {:argument_error, map}}
       _                                        ->
         {:ok,    []}
     end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -49,8 +49,8 @@ defmodule Antikythera.Zip do
       :ok           <- validate_path_type(src_path, true),
       :ok           <- validate_within_tmpdir(zip_path, tmpdir),
       :ok           <- validate_within_tmpdir(src_path, tmpdir),
-      :ok           <- ensure_dir_exists(zip_path, tmpdir),
-      :ok           <- ensure_path_exists(src_path),
+      :ok           <- ensure_path_exists(zip_path, tmpdir),
+      :ok           <- validate_path_exists(src_path),
       {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
       :ok           <- try_zip_cmd(args ++ [zip_path, src_path])
     ) do
@@ -82,7 +82,7 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
+  defunp ensure_path_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok do
     path
     |> Path.dirname()
     |> String.trim_leading(tmpdir <> "/")
@@ -96,7 +96,7 @@ defmodule Antikythera.Zip do
     :ok
   end
 
-  defunp ensure_path_exists(path :: v[String.t]) :: :ok | {:error, tuple} do
+  defunp validate_path_exists(path :: v[String.t]) :: :ok | {:error, tuple} do
     if path |> Path.expand() |> File.exists?() do
       :ok
     else

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -67,17 +67,17 @@ defmodule Antikythera.Zip do
   defp extract_epool_id(%Context{executor_pool_id: epool_id}), do: epool_id
   defp extract_epool_id(epool_id),                             do: epool_id
 
-  defunp validate_suffix(path :: v[String.t]) :: :ok | {:error, tuple} do
-    if String.ends_with?(path, "/") and !File.dir?(path) do
-      {:error, {:not_dir, %{path: path}}}
+  defunp reject_existing_dir(path :: v[String.t]) :: :ok | {:error, tuple} do
+    if File.dir?(path) do
+      {:error, {:is_dir, %{path: path}}}
     else
       :ok
     end
   end
 
-  defunp reject_existing_dir(path :: v[String.t]) :: :ok | {:error, tuple} do
-    if File.dir?(path) do
-      {:error, {:is_dir, %{path: path}}}
+  defunp validate_suffix(path :: v[String.t]) :: :ok | {:error, tuple} do
+    if String.ends_with?(path, "/") and !File.dir?(path) do
+      {:error, {:not_dir, %{path: path}}}
     else
       :ok
     end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -69,14 +69,14 @@ defmodule Antikythera.Zip do
         :file
       end
     cond do
-      type not in types                ->
-        {:error, {:invalid_path_type, %{path: path, type: type}}}
-      type == :file                    ->
+      type == :file     ->
         :ok
-      type == :dir and File.dir?(path) ->
+      type not in types ->
+        {:error, {:is_dir, %{path: path}}}
+      File.dir?(path)   ->
         :ok
-      true ->
-        {:error, {:not_directory, %{path: path}}}
+      true              ->
+        {:error, {:not_dir, %{path: path}}}
     end
   end
 

--- a/test/core/sup_tree_core/tmpdir_tracker_test.exs
+++ b/test/core/sup_tree_core/tmpdir_tracker_test.exs
@@ -3,7 +3,6 @@
 defmodule AntikytheraCore.TmpdirTrackerTest do
   use Croma.TestCase
   alias Antikythera.Tmpdir
-  alias AntikytheraCore.TmpdirTracker
 
   @context Antikythera.Test.ConnHelper.make_conn().context
 

--- a/test/core/sup_tree_core/tmpdir_tracker_test.exs
+++ b/test/core/sup_tree_core/tmpdir_tracker_test.exs
@@ -1,0 +1,22 @@
+# Copyright(c) 2015-2019 ACCESS CO., LTD. All rights reserved.
+
+defmodule AntikytheraCore.TmpdirTrackerTest do
+  use ExUnit.Case
+  alias Antikythera.Tmpdir
+  alias AntikytheraCore.TmpdirTracker
+
+  @context Antikythera.Test.ConnHelper.make_conn().context
+
+  test "TmpdirTracker.get/1 returns tmpdir only within Tmpdir.make/2" do
+    assert %{
+      tmpdir: tmpdir,
+      actual: {:ok, tmpdir},
+    } = Tmpdir.make(@context, fn tmpdir ->
+      %{
+        tmpdir: tmpdir,
+        actual: TmpdirTracker.get(@context.executor_pool_id),
+      }
+    end)
+    assert {:error, {:not_found, _}} = TmpdirTracker.get(@context.executor_pool_id)
+  end
+end

--- a/test/core/sup_tree_core/tmpdir_tracker_test.exs
+++ b/test/core/sup_tree_core/tmpdir_tracker_test.exs
@@ -8,15 +8,9 @@ defmodule AntikytheraCore.TmpdirTrackerTest do
   @context Antikythera.Test.ConnHelper.make_conn().context
 
   test "TmpdirTracker.get/1 returns tmpdir only within Tmpdir.make/2" do
-    assert %{
-      tmpdir: tmpdir,
-      actual: {:ok, tmpdir},
-    } = Tmpdir.make(@context, fn tmpdir ->
-      %{
-        tmpdir: tmpdir,
-        actual: TmpdirTracker.get(@context.executor_pool_id),
-      }
+    Tmpdir.make(@context, fn tmpdir ->
+      assert {:ok, tmpdir} == TmpdirTracker.get(@context.executor_pool_id)
     end)
-    assert {:error, :not_found} = TmpdirTracker.get(@context.executor_pool_id)
+    assert {:error, :not_found} == TmpdirTracker.get(@context.executor_pool_id)
   end
 end

--- a/test/core/sup_tree_core/tmpdir_tracker_test.exs
+++ b/test/core/sup_tree_core/tmpdir_tracker_test.exs
@@ -17,6 +17,6 @@ defmodule AntikytheraCore.TmpdirTrackerTest do
         actual: TmpdirTracker.get(@context.executor_pool_id),
       }
     end)
-    assert {:error, {:not_found, _}} = TmpdirTracker.get(@context.executor_pool_id)
+    assert {:error, :not_found} = TmpdirTracker.get(@context.executor_pool_id)
   end
 end

--- a/test/core/sup_tree_core/tmpdir_tracker_test.exs
+++ b/test/core/sup_tree_core/tmpdir_tracker_test.exs
@@ -1,7 +1,7 @@
 # Copyright(c) 2015-2019 ACCESS CO., LTD. All rights reserved.
 
 defmodule AntikytheraCore.TmpdirTrackerTest do
-  use ExUnit.Case
+  use Croma.TestCase
   alias Antikythera.Tmpdir
   alias AntikytheraCore.TmpdirTracker
 

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -51,5 +51,23 @@ defmodule Antikythera.ZipTest do
       :meck.expect(File, :exists?, fn _ -> flunk() end)
       assert Zip.zip(@context, zip_path, src_path) == {:error, {:not_found, %{}}}
     end
+
+    test "returns error when src is outside tmpdir" do
+      tmpdir = "/tmpdir"
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, tmpdir} end)
+      zip_path = "/tmpdir/archive.zip"
+      src_path = "/another_dir/src.txt"
+      :meck.expect(File, :exists?, fn _ -> flunk() end)
+      assert Zip.zip(@context, zip_path, src_path) == {:error, {:permission_denied, %{path: src_path, tmpdir: tmpdir}}}
+    end
+
+    test "returns error when resulting archive is outside tmpdir" do
+      tmpdir = "/tmpdir"
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, tmpdir} end)
+      zip_path = "/another_dir/archive.zip"
+      src_path = "/tmpdir/src.txt"
+      :meck.expect(File, :exists?, fn _ -> flunk() end)
+      assert Zip.zip(@context, zip_path, src_path) == {:error, {:permission_denied, %{path: zip_path, tmpdir: tmpdir}}}
+    end
   end
 end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -124,7 +124,7 @@ defmodule Antikythera.ZipTest do
         zip_path = tmpdir <> "/archive.zip"
         src_path = tmpdir <> "/src.txt"
         :meck.expect(File, :exists?, fn ^src_path -> true end)
-        assert {:error, {:shell_runtime_error, _}} = Zip.zip(@context, zip_path, src_path)
+        assert {:error, :shell_runtime_error} = Zip.zip(@context, zip_path, src_path)
       end)
     end
   end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -98,12 +98,11 @@ defmodule Antikythera.ZipTest do
     end
 
     test "returns error when zip path is through existing file name" do
-      Tmpdir.make(@context, fn tmpdir ->
-        src_path = tmpdir <> "/src.txt"
-        zip_path = tmpdir <> "/src.txt/beneath_the_file.zip"
-        File.write!(src_path, "text")
-        assert Zip.zip(@context, zip_path, src_path) == {:error, {:not_dir, %{path: zip_path}}}
-      end)
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
+      zip_path = @src_path <> "/beneath_the_file.zip"
+      :meck.expect(File, :exists?, fn @src_path -> true end)
+      :meck.expect(File, :mkdir_p, fn @src_path -> {:error, :eexist} end)
+      assert Zip.zip(@context, zip_path, @src_path) == {:error, {:not_dir, %{path: zip_path}}}
     end
 
     test "returns error when encryption is disabled and password exists" do

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -2,6 +2,7 @@
 
 defmodule Antikythera.ZipTest do
   use Croma.TestCase
+  alias AntikytheraCore.TmpdirTracker
   alias Antikythera.{Tmpdir, Zip}
 
   setup do
@@ -41,6 +42,14 @@ defmodule Antikythera.ZipTest do
           assert Zip.zip(@context, zip_path, tmpdir <> path_to_archive, [encryption: true, password: "password"]) == {:ok, zip_path}
         end)
       end)
+    end
+
+    test "returns error when tmpdir is not found" do
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:error, {:not_found, %{}}} end)
+      zip_path = "/tmpdir/archive.zip"
+      src_path = "/tmpdir/src.txt"
+      :meck.expect(File, :exists?, fn _ -> flunk() end)
+      assert Zip.zip(@context, zip_path, src_path) == {:error, {:not_found, %{}}}
     end
   end
 end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -69,5 +69,29 @@ defmodule Antikythera.ZipTest do
       :meck.expect(File, :exists?, fn _ -> flunk() end)
       assert Zip.zip(@context, zip_path, src_path) == {:error, {:permission_denied, %{path: zip_path, tmpdir: tmpdir}}}
     end
+
+    test "returns error when src is not found" do
+      tmpdir = "/tmpdir"
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, tmpdir} end)
+      zip_path = "/tmpdir/archive.zip"
+      src_path = "/tmpdir/src.txt"
+      :meck.expect(File, :exists?, fn
+        ^zip_path -> false
+        ^src_path -> false
+      end)
+      assert Zip.zip(@context, zip_path, src_path) == {:error, {:not_found, %{path: src_path}}}
+    end
+
+    test "returns error when resulting archive already exists" do
+      tmpdir = "/tmpdir"
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, tmpdir} end)
+      zip_path = "/tmpdir/archive.zip"
+      src_path = "/tmpdir/src.txt"
+      :meck.expect(File, :exists?, fn
+        ^zip_path -> true
+        ^src_path -> true
+      end)
+      assert Zip.zip(@context, zip_path, src_path) == {:error, {:already_exists, %{path: zip_path}}}
+    end
   end
 end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -3,7 +3,7 @@
 defmodule Antikythera.ZipTest do
   use Croma.TestCase
   alias AntikytheraCore.TmpdirTracker
-  alias Antikythera.{Tmpdir, Zip}
+  alias Antikythera.Tmpdir
 
   setup do
     on_exit(&:meck.unload/0)

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -17,9 +17,11 @@ defmodule Antikythera.ZipTest do
   describe "Zip.FileName.valid?/1" do
     test "Exclude paths suffixed with /" do
       assert Zip.FileName.valid?("/dir/file.ex")
+      assert Zip.FileName.valid?("/dir/file.")
       refute Zip.FileName.valid?("/dir/")
       refute Zip.FileName.valid?("/dir/.")
       refute Zip.FileName.valid?("/dir/..")
+      assert Zip.FileName.valid?("/dir/...")
     end
   end
 

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -18,6 +18,7 @@ defmodule Antikythera.ZipTest do
     test "Exclude paths suffixed with /" do
       assert Zip.FileName.valid?("/dir/file.ex")
       assert Zip.FileName.valid?("/dir/file.")
+      refute Zip.FileName.valid?("/dir/file\n")
       refute Zip.FileName.valid?("/dir/")
       refute Zip.FileName.valid?("/dir/.")
       refute Zip.FileName.valid?("/dir/..")

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -1,0 +1,46 @@
+# Copyright(c) 2015-2019 ACCESS CO., LTD. All rights reserved.
+
+defmodule Antikythera.ZipTest do
+  use Croma.TestCase
+  alias Antikythera.{Tmpdir, Zip}
+
+  setup do
+    on_exit(&:meck.unload/0)
+  end
+
+  @context Antikythera.Test.ConnHelper.make_conn().context
+
+  describe "Zip.zip/3" do
+    test "returns path of resulting archive" do
+      [
+        {[],            ["/src.txt"],         "/src.txt"},
+        {["/src_dir/"], [],                   "/src_dir/"},
+        {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
+      ]
+      |> Enum.each(fn {dirs_to_create, files_to_write, path_to_archive} ->
+        Tmpdir.make(@context, fn tmpdir ->
+          zip_path = tmpdir <> "/archive.zip"
+          Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
+          Enum.each(files_to_write, &File.write!(tmpdir <> &1, "text"))
+          assert Zip.zip(@context, zip_path, tmpdir <> path_to_archive) == {:ok, zip_path}
+        end)
+      end)
+    end
+
+    test "returns path of resulting archive encrypted with password" do
+      [
+        {[],            ["/src.txt"],         "/src.txt"},
+        {["/src_dir/"], [],                   "/src_dir/"},
+        {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
+      ]
+      |> Enum.each(fn {dirs_to_create, files_to_write, path_to_archive} ->
+        Tmpdir.make(@context, fn tmpdir ->
+          zip_path = tmpdir <> "/archive.zip"
+          Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
+          Enum.each(files_to_write, &File.write!(tmpdir <> &1, "text"))
+          assert Zip.zip(@context, zip_path, tmpdir <> path_to_archive, [encryption: true, password: "password"]) == {:ok, zip_path}
+        end)
+      end)
+    end
+  end
+end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -105,5 +105,17 @@ defmodule Antikythera.ZipTest do
       end)
       assert Zip.zip(@context, zip_path, src_path, [encryption: false, password: "password"]) == {:error, {:argument_error, %{encryption: false, password: "password"}}}
     end
+
+    test "returns error when shell command fails" do
+      Tmpdir.make(@context, fn tmpdir ->
+        zip_path = tmpdir <> "/archive.zip"
+        src_path = tmpdir <> "/src.txt"
+        :meck.expect(File, :exists?, fn
+          ^zip_path -> false
+          ^src_path -> true
+        end)
+        assert {:error, {:shell_runtime_error, _}} = Zip.zip(@context, zip_path, src_path)
+      end)
+    end
   end
 end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -64,6 +64,12 @@ defmodule Antikythera.ZipTest do
       end
     end
 
+    test "returns error when a directory exists with same name as resulting archive" do
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
+      :meck.expect(File, :dir?, fn @zip_path -> true end)
+      assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:is_dir, %{path: @zip_path}}}
+    end
+
     test "returns error when input file name is suffixed with / while it is a file" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       src_path = "/tmpdir/src/"

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -62,6 +62,13 @@ defmodule Antikythera.ZipTest do
       end
     end
 
+    test "returns error when input file name is suffixed with / while it is a file" do
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
+      src_path = "/tmpdir/src/"
+      :meck.expect(File, :dir?, fn _path -> false end)
+      assert Zip.zip(@context, @zip_path, src_path) == {:error, {:not_dir, %{path: src_path}}}
+    end
+
     test "returns error when tmpdir is not found" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:error, {:not_found, %{}}} end)
       :meck.expect(File, :exists?, fn _ -> flunk() end)

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -81,7 +81,7 @@ defmodule Antikythera.ZipTest do
 
     test "returns error when tmpdir is not found" do
       :meck.expect(File, :exists?, fn _ -> flunk() end)
-      assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:not_found, %{}}}
+      assert Zip.zip(@context, @zip_path, @src_path) == {:error, :not_found}
     end
 
     test "returns error when src is outside tmpdir" do

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -93,5 +93,17 @@ defmodule Antikythera.ZipTest do
       end)
       assert Zip.zip(@context, zip_path, src_path) == {:error, {:already_exists, %{path: zip_path}}}
     end
+
+    test "returns error when encryption is disabled and password exists" do
+      tmpdir = "/tmpdir"
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, tmpdir} end)
+      zip_path = "/tmpdir/archive.zip"
+      src_path = "/tmpdir/src.txt"
+      :meck.expect(File, :exists?, fn
+        ^zip_path -> false
+        ^src_path -> true
+      end)
+      assert Zip.zip(@context, zip_path, src_path, [encryption: false, password: "password"]) == {:error, {:argument_error, %{encryption: false, password: "password"}}}
+    end
   end
 end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -48,6 +48,16 @@ defmodule Antikythera.ZipTest do
       end
     end
 
+    test "returns path of resulting archive with .zip if no extension was assigned" do
+      Tmpdir.make(@context, fn tmpdir ->
+        zip_path = tmpdir <> "/no_extension"
+        src_path = tmpdir <> "/src.txt"
+        File.write!(src_path, "text")
+        assert Zip.zip(@context, zip_path, src_path) == {:ok, zip_path <> ".zip"}
+        assert File.exists?(zip_path <> ".zip")
+      end)
+    end
+
     test "returns path of resulting archive encrypted with password" do
       for(
         {dirs_to_create, files_to_create, src_path} <- [

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -114,7 +114,13 @@ defmodule Antikythera.ZipTest do
     test "returns error when encryption is disabled and password exists" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       :meck.expect(File, :exists?, fn @src_path -> true end)
-      assert Zip.zip(@context, @zip_path, @src_path, [encryption: false, password: "password"]) == {:error, {:argument_error, %{encryption: false, password: "password"}}}
+      [
+        {[encryption: false, password: "password"], %{encryption: false, password: "password"}},
+        {[encryption: true,  password: ""],         %{encryption: true,  password: ""}},
+        {[encryption: true],                        %{encryption: true}},
+      ] |> Enum.each(fn {invalid_args, expected} ->
+        assert Zip.zip(@context, @zip_path, @src_path, invalid_args) == {:error, {:argument_error, expected}}
+      end)
     end
 
     test "returns error when shell command fails" do

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -98,15 +98,6 @@ defmodule Antikythera.ZipTest do
       assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:not_found, %{path: @src_path}}}
     end
 
-    test "returns error when resulting archive already exists" do
-      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      :meck.expect(File, :exists?, fn
-        @zip_path -> true
-        @src_path -> true
-      end)
-      assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:already_exists, %{path: @zip_path}}}
-    end
-
     test "returns error when encryption is disabled and password exists" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       :meck.expect(File, :exists?, fn

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -14,6 +14,13 @@ defmodule Antikythera.ZipTest do
   @src_path "/tmpdir/src.txt"
   @zip_path "/tmpdir/archive.zip"
 
+  describe "Zip.Filename.valid?/1" do
+    test "Exclude paths suffixed with /" do
+      assert Zip.Filename.valid?("/dir/file.ex")
+      refute Zip.Filename.valid?("/dir/")
+    end
+  end
+
   describe "Zip.zip/3" do
     test "returns path of resulting archive" do
       for(

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -40,6 +40,7 @@ defmodule Antikythera.ZipTest do
           Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
           Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
           assert Zip.zip(@context, tmpdir <> zip_path, tmpdir <> src_path) == {:ok, tmpdir <> zip_path}
+          assert File.exists?(tmpdir <> zip_path)
         end)
       end
     end
@@ -60,6 +61,7 @@ defmodule Antikythera.ZipTest do
           Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
           Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
           assert Zip.zip(@context, tmpdir <> zip_path, tmpdir <> src_path, [encryption: true, password: "password"]) == {:ok, tmpdir <> zip_path}
+          assert File.exists?(tmpdir <> zip_path)
         end)
       end
     end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -91,19 +91,13 @@ defmodule Antikythera.ZipTest do
 
     test "returns error when src is not found" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      :meck.expect(File, :exists?, fn
-        @zip_path -> false
-        @src_path -> false
-      end)
+      :meck.expect(File, :exists?, fn @src_path -> false end)
       assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:not_found, %{path: @src_path}}}
     end
 
     test "returns error when encryption is disabled and password exists" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      :meck.expect(File, :exists?, fn
-        @zip_path -> false
-        @src_path -> true
-      end)
+      :meck.expect(File, :exists?, fn @src_path -> true end)
       assert Zip.zip(@context, @zip_path, @src_path, [encryption: false, password: "password"]) == {:error, {:argument_error, %{encryption: false, password: "password"}}}
     end
 
@@ -111,10 +105,7 @@ defmodule Antikythera.ZipTest do
       Tmpdir.make(@context, fn tmpdir ->
         zip_path = tmpdir <> "/archive.zip"
         src_path = tmpdir <> "/src.txt"
-        :meck.expect(File, :exists?, fn
-          ^zip_path -> false
-          ^src_path -> true
-        end)
+        :meck.expect(File, :exists?, fn ^src_path -> true end)
         assert {:error, {:shell_runtime_error, _}} = Zip.zip(@context, zip_path, src_path)
       end)
     end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -97,6 +97,15 @@ defmodule Antikythera.ZipTest do
       assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:not_found, %{path: @src_path}}}
     end
 
+    test "returns error when zip path is through existing file name" do
+      Tmpdir.make(@context, fn tmpdir ->
+        src_path = tmpdir <> "/src.txt"
+        zip_path = tmpdir <> "/src.txt/beneath_the_file.zip"
+        File.write!(src_path, "text")
+        assert Zip.zip(@context, zip_path, src_path) == {:error, {:not_dir, %{path: zip_path}}}
+      end)
+    end
+
     test "returns error when encryption is disabled and password exists" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       :meck.expect(File, :exists?, fn @src_path -> true end)

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -18,6 +18,8 @@ defmodule Antikythera.ZipTest do
     test "Exclude paths suffixed with /" do
       assert Zip.FileName.valid?("/dir/file.ex")
       refute Zip.FileName.valid?("/dir/")
+      refute Zip.FileName.valid?("/dir/.")
+      refute Zip.FileName.valid?("/dir/..")
     end
   end
 

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -14,10 +14,10 @@ defmodule Antikythera.ZipTest do
   @src_path "/tmpdir/src.txt"
   @zip_path "/tmpdir/archive.zip"
 
-  describe "Zip.Filename.valid?/1" do
+  describe "Zip.FileName.valid?/1" do
     test "Exclude paths suffixed with /" do
-      assert Zip.Filename.valid?("/dir/file.ex")
-      refute Zip.Filename.valid?("/dir/")
+      assert Zip.FileName.valid?("/dir/file.ex")
+      refute Zip.FileName.valid?("/dir/")
     end
   end
 

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -16,35 +16,43 @@ defmodule Antikythera.ZipTest do
 
   describe "Zip.zip/3" do
     test "returns path of resulting archive" do
-      [
-        {[],            ["/src.txt"],         "/src.txt"},
-        {["/src_dir/"], [],                   "/src_dir/"},
-        {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
-      ]
-      |> Enum.each(fn {dirs_to_create, files_to_create, src_path} ->
+      for(
+        {dirs_to_create, files_to_create, src_path} <- [
+          {[],            ["/src.txt"],         "/src.txt"},
+          {["/src_dir/"], [],                   "/src_dir/"},
+          {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
+        ],
+        zip_path <- [
+          "/archive.zip",
+          "/zip_dir/archive.zip",
+        ]
+      ) do
         Tmpdir.make(@context, fn tmpdir ->
-          zip_path = tmpdir <> "/archive.zip"
           Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
           Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
-          assert Zip.zip(@context, zip_path, tmpdir <> src_path) == {:ok, zip_path}
+          assert Zip.zip(@context, tmpdir <> zip_path, tmpdir <> src_path) == {:ok, tmpdir <> zip_path}
         end)
-      end)
+      end
     end
 
     test "returns path of resulting archive encrypted with password" do
-      [
-        {[],            ["/src.txt"],         "/src.txt"},
-        {["/src_dir/"], [],                   "/src_dir/"},
-        {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
-      ]
-      |> Enum.each(fn {dirs_to_create, files_to_create, src_path} ->
+      for(
+        {dirs_to_create, files_to_create, src_path} <- [
+          {[],            ["/src.txt"],         "/src.txt"},
+          {["/src_dir/"], [],                   "/src_dir/"},
+          {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
+        ],
+        zip_path <- [
+          "/archive.zip",
+          "/zip_dir/archive.zip",
+        ]
+      ) do
         Tmpdir.make(@context, fn tmpdir ->
-          zip_path = tmpdir <> "/archive.zip"
           Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
           Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
-          assert Zip.zip(@context, zip_path, tmpdir <> src_path, [encryption: true, password: "password"]) == {:ok, zip_path}
+          assert Zip.zip(@context, tmpdir <> zip_path, tmpdir <> src_path, [encryption: true, password: "password"]) == {:ok, tmpdir <> zip_path}
         end)
-      end)
+      end
     end
 
     test "returns error when tmpdir is not found" do

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -18,12 +18,12 @@ defmodule Antikythera.ZipTest do
         {["/src_dir/"], [],                   "/src_dir/"},
         {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
       ]
-      |> Enum.each(fn {dirs_to_create, files_to_write, path_to_archive} ->
+      |> Enum.each(fn {dirs_to_create, files_to_create, src_path} ->
         Tmpdir.make(@context, fn tmpdir ->
           zip_path = tmpdir <> "/archive.zip"
           Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
-          Enum.each(files_to_write, &File.write!(tmpdir <> &1, "text"))
-          assert Zip.zip(@context, zip_path, tmpdir <> path_to_archive) == {:ok, zip_path}
+          Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
+          assert Zip.zip(@context, zip_path, tmpdir <> src_path) == {:ok, zip_path}
         end)
       end)
     end
@@ -34,12 +34,12 @@ defmodule Antikythera.ZipTest do
         {["/src_dir/"], [],                   "/src_dir/"},
         {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
       ]
-      |> Enum.each(fn {dirs_to_create, files_to_write, path_to_archive} ->
+      |> Enum.each(fn {dirs_to_create, files_to_create, src_path} ->
         Tmpdir.make(@context, fn tmpdir ->
           zip_path = tmpdir <> "/archive.zip"
           Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
-          Enum.each(files_to_write, &File.write!(tmpdir <> &1, "text"))
-          assert Zip.zip(@context, zip_path, tmpdir <> path_to_archive, [encryption: true, password: "password"]) == {:ok, zip_path}
+          Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
+          assert Zip.zip(@context, zip_path, tmpdir <> src_path, [encryption: true, password: "password"]) == {:ok, zip_path}
         end)
       end)
     end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -80,7 +80,6 @@ defmodule Antikythera.ZipTest do
     end
 
     test "returns error when tmpdir is not found" do
-      :meck.expect(TmpdirTracker, :get, fn _ -> {:error, {:not_found, %{}}} end)
       :meck.expect(File, :exists?, fn _ -> flunk() end)
       assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:not_found, %{}}}
     end
@@ -101,7 +100,6 @@ defmodule Antikythera.ZipTest do
 
     test "returns error when src is not found" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      :meck.expect(File, :exists?, fn @src_path -> false end)
       assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:not_found, %{path: @src_path}}}
     end
 


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/177185

Abstract:
Implemented a wrapper module for `zip` shell command.

Purpose:
To add feature to generate password-encrypted ZIP file from a *gear*.
I chose to use shell command because it is the only cost-effective way which can suffice such a feature.

Limitations:
Along with newly utilizing a shell command, it is aided with limited permission to the local file systems.
In detail,
I added an interface `AntikytheraCore.TmpdirTracker.get/1` to get the path to currently used `tmpdir`.
After applying this interface, it is ensured:
- that it can be called from only within `Tmpdir.make/2` call,
- that the path for input file/directory is under `tmpdir`,
- that the path for resulting archive is under `tmpdir`.

I appreciate your suggestions.