### PR TITLE
[177185] Compensate zip command in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
       # Installing `locales` automatically triggers `locale-gen` once in postinstall step
       command: |
         echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
-        apt-get update && apt-get install -y unzip locales
+        apt-get update && apt-get install -y zip unzip locales
         echo 'export LANG=en_US.UTF-8' >> $BASH_ENV
   restore_asdf_directory: &restore_asdf_directory
     restore_cache:


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/177185

Fixed CircleCI config to install `zip` command in test environment.
Blackbox tests for `Antikythera.Zip`, previously added in #44, has been failed because `zip` command was not found on CircleCI environment.