### PR TITLE
[177185] Add macro to separate cmd fun

### DIFF
--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -105,19 +105,19 @@ quote do
         end
       end
 
-  defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok | {:error, tuple} do
-    dirname = Path.dirname(path)
-    if dirname != tmpdir do
-      case File.mkdir_p(dirname) do
-        :ok ->
+      defunp ensure_dir_exists(path :: v[String.t], tmpdir :: v[String.t]) :: :ok | {:error, tuple} do
+        dirname = Path.dirname(path)
+        if dirname != tmpdir do
+          case File.mkdir_p(dirname) do
+            :ok ->
+              :ok
+            {:error, :eexist} ->
+              {:error, {:not_dir, %{path: path}}}
+          end
+        else
           :ok
-        {:error, :eexist} ->
-          {:error, {:not_dir, %{path: path}}}
+        end
       end
-    else
-      :ok
-    end
-  end
 
       defunp extract_zip_args(map :: map) :: R.t(list(String.t)) do
         case map do

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -17,16 +17,16 @@ end
 defmodule Antikythera.Zip.ModuleTemplate do
 defmacro __using__([cmd: cmd]) do
 quote do
-  alias Croma.Result, as: R
-  alias Antikythera.Context
-  alias Antikythera.ExecutorPool.Id, as: EPoolId
-  alias AntikytheraCore.TmpdirTracker
+      alias Croma.Result, as: R
+      alias Antikythera.Context
+      alias Antikythera.ExecutorPool.Id, as: EPoolId
+      alias AntikytheraCore.TmpdirTracker
 
-  @typep opts :: {:encryption, boolean} | {:password, String.t}
+      @typep opts :: {:encryption, boolean} | {:password, String.t}
 
-  defmodule FileName do
-    use Croma.SubtypeOfString, pattern: ~R/^(?!.*\/\.{0,2}\z).*\z/
-  end
+      defmodule FileName do
+        use Croma.SubtypeOfString, pattern: ~R/^(?!.*\/\.{0,2}\z).*\z/
+      end
 
       @doc """
       Creates a ZIP file.

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -11,6 +11,12 @@ defmodule Antikythera.Zip do
   Functions only accept absolute paths for both source and resulting archive.
   """
 
+  use Antikythera.Zip.ModuleTemplate, cmd: &System.cmd("zip", &1)
+end
+
+defmodule Antikythera.Zip.ModuleTemplate do
+defmacro __using__([cmd: cmd]) do
+quote do
   alias Croma.Result, as: R
   alias Antikythera.Context
   alias Antikythera.ExecutorPool.Id, as: EPoolId
@@ -129,11 +135,17 @@ defmodule Antikythera.Zip do
   end
 
   defunp try_zip_cmd(args :: v[list(String.t)]) :: :ok | {:error, :shell_runtime_error} do
-    case System.cmd("zip", args) do
+    case cmd(args) do
       {_, 0} ->
         :ok
       _ ->
         {:error, :shell_runtime_error}
     end
   end
+
+  defunpt cmd(args :: v[list(String.t)]) :: {binary, integer} do
+    unquote(cmd).(args)
+  end
+end
+end
 end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -2,18 +2,6 @@
 
 use Croma
 
-defmodule Antikythera.Zip do
-  @moduledoc """
-  Wrapper module for `zip` command.
-
-  For the consistency in working with antikythera and other gears, scope of this module is limited under a temporary directory reserved by `Antikythera.Tmpdir.make/2`.
-
-  Functions only accept absolute paths for both source and resulting archive.
-  """
-
-  use Antikythera.Zip.ModuleTemplate, cmd: &System.cmd("zip", &1)
-end
-
 defmodule Antikythera.Zip.ModuleTemplate do
   defmacro __using__([cmd: cmd]) do
     quote do
@@ -148,4 +136,16 @@ defmodule Antikythera.Zip.ModuleTemplate do
       end
     end
   end
+end
+
+defmodule Antikythera.Zip do
+  @moduledoc """
+  Wrapper module for `zip` command.
+
+  For the consistency in working with antikythera and other gears, scope of this module is limited under a temporary directory reserved by `Antikythera.Tmpdir.make/2`.
+
+  Functions only accept absolute paths for both source and resulting archive.
+  """
+
+  use Antikythera.Zip.ModuleTemplate, cmd: &System.cmd("zip", &1)
 end

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -15,8 +15,8 @@ defmodule Antikythera.Zip do
 end
 
 defmodule Antikythera.Zip.ModuleTemplate do
-defmacro __using__([cmd: cmd]) do
-quote do
+  defmacro __using__([cmd: cmd]) do
+    quote do
       alias Croma.Result, as: R
       alias Antikythera.Context
       alias Antikythera.ExecutorPool.Id, as: EPoolId
@@ -146,6 +146,6 @@ quote do
       defunpt cmd(args :: v[list(String.t)]) :: {binary, integer} do
         unquote(cmd).(args)
       end
-end
-end
+    end
+  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -17,7 +17,7 @@
   "fast_xml": {:hex, :fast_xml, "1.1.34", "d76fc639d3607a44c4f0fb2dfdee1067b6c37b02b39706d8f067cb77eb2f6016", [:rebar3], [{:p1_utils, "1.0.13", [hex: :p1_utils, repo: "hexpm", optional: false]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
   "foretoken": {:hex, :foretoken, "0.3.0", "4305a2ee94886d9199ecc36dd2e5cef75795195b9b65c22e85ed656eea03f4ba", [:mix], [{:croma, "~> 0.9", [hex: :croma, repo: "hexpm", optional: false]}], "hexpm"},
-  "getopt": {:hex, :getopt, "0.8.2", "b17556db683000ba50370b16c0619df1337e7af7ecbf7d64fbf8d1d6bce3109b", [:rebar], [], "hexpm"},
+  "getopt": {:hex, :getopt, "0.8.2", "b17556db683000ba50370b16c0619df1337e7af7ecbf7d64fbf8d1d6bce3109b", [:rebar3], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.16.1", "e2130b25eebcbe02bb343b119a07ae2c7e28bd4b146c4a154da2ffb2b3507af2", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.14.3", "b5f6f5dcc4f1fba340762738759209e21914516df6be440d85772542d4a5e412", [:rebar3], [{:certifi, "2.4.2", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/177185

I want to suggest a simple, but questionable fix in `Antikythera.Zip`.

I noticed that `Antikythera.Zip` module ends in experiencing whole turnaround using macro, passing through `&System.cmd("zip", &1)` as the sole parameter.
This is for testing; mainly because `System.cmd/2` cannot be mocked.
Or, are there any other methods for testing?