### PR TITLE
[177185] Use relative path for zip library

### DIFF
--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -53,6 +53,7 @@ defmodule Antikythera.Zip do
          :ok           <- validate_within_tmpdir(cwd_path, tmpdir),
          :ok           <- validate_within_tmpdir(zip_path, tmpdir),
          :ok           <- validate_within_tmpdir(src_path, tmpdir),
+         :ok           <- reject_existing_file(cwd_path),
          :ok           <- reject_existing_dir(zip_path),
          :ok           <- ensure_dir_exists(zip_path, tmpdir),
          :ok           <- validate_path_exists(src_path),
@@ -69,6 +70,14 @@ defmodule Antikythera.Zip do
 
   defp extract_epool_id(%Context{executor_pool_id: epool_id}), do: epool_id
   defp extract_epool_id(epool_id),                             do: epool_id
+
+  defunp reject_existing_file(path :: v[String.t]) :: :ok | {:error, tuple} do
+    if File.dir?(path) do
+      :ok
+    else
+      {:error, {:not_dir, %{path: path}}}
+    end
+  end
 
   defunp reject_existing_dir(path :: v[String.t]) :: :ok | {:error, tuple} do
     if File.dir?(path) do

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -88,7 +88,7 @@ defmodule Antikythera.Zip do
   end
 
   defunp validate_within_tmpdir(path :: v[String.t], tmpdir :: v[String.t]) :: :ok | {:error, tuple} do
-    if String.starts_with?(path, "#{tmpdir}/") do
+    if path == tmpdir or String.starts_with?(path, "#{tmpdir}/") do
       :ok
     else
       {:error, {:permission_denied, %{path: path, tmpdir: tmpdir}}}

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -77,8 +77,10 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp validate_suffix(path :: v[String.t]) :: :ok | {:error, tuple} do
-    if String.ends_with?(path, "/") and !File.dir?(path) do
+  defunp validate_suffix(src_raw_path :: v[String.t], cwd_path :: v[String.t]) :: :ok | {:error, tuple} do
+    suffixed = String.ends_with?(src_raw_path, "/")
+    path = Path.expand(src_raw_path, cwd_path)
+    if suffixed and !File.dir?(path) do
       {:error, {:not_dir, %{path: path}}}
     else
       :ok

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -50,6 +50,7 @@ defmodule Antikythera.Zip do
          cwd_path      <- Path.expand(cwd_raw_path),
          zip_path      <- Path.expand(zip_raw_path, cwd_path),
          src_path      <- Path.expand(src_raw_path, cwd_path),
+         :ok           <- validate_within_tmpdir(cwd_path, tmpdir),
          :ok           <- validate_within_tmpdir(zip_path, tmpdir),
          :ok           <- validate_within_tmpdir(src_path, tmpdir),
          :ok           <- reject_existing_dir(zip_path),

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -19,7 +19,7 @@ defmodule Antikythera.Zip do
   @typep opts :: {:encryption, boolean} | {:password, String.t}
 
   defmodule FileName do
-    use Croma.SubtypeOfString, pattern: ~R/^(?!.*\/\.{0,2}\z).*\z/
+    use Croma.SubtypeOfString, pattern: ~R/\A(?!.*\/\.{0,2}\z).*\z/
   end
 
   @doc """

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -6,7 +6,13 @@ defmodule Antikythera.Zip do
   @moduledoc """
   Wrapper module for `zip` command.
 
-  For the consistency in working with antikythera and other gears, scope of this module is limited under a temporary directory reserved by `Antikythera.Tmpdir.make/2`.
+  For the security and consistency in working with antikythera and other gears,
+
+  scopes of
+  - working directory
+  - input file
+  - output file
+  are limited under a temporary directory reserved by `Antikythera.Tmpdir.make/2`.
 
   Functions only accept absolute paths for both source and resulting archive.
   """

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -39,9 +39,9 @@ defmodule Antikythera.Zip do
 
   ## Example
     Tmpdir.make(context, fn tmpdir ->
-      src_path = tmpdir <> "/src.txt"
-      zip_path = tmpdir <> "/archive.zip"
-      File.write!(src_path, "text")
+      src_path = "src.txt"
+      zip_path = "archive.zip"
+      File.write!(tmpdir <> "/" <> src_path, "text")
       Antikythera.Zip.zip(context, tmpdir, zip_path, src_path, [encryption: true, password: "password"])
       |> case do
         {:ok, archive_path} ->

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -6,12 +6,12 @@ defmodule Antikythera.Zip do
   @moduledoc """
   Wrapper module for `zip` command.
 
-  For the security and consistency in working with antikythera and other gears,
+  For the security and consistency in working with antikythera and other gears, scopes of
 
-  scopes of
   - working directory
   - input file
   - output file
+
   are limited under a temporary directory reserved by `Antikythera.Tmpdir.make/2`.
 
   Functions only accept absolute paths for both source and resulting archive.

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -62,7 +62,6 @@ defmodule Antikythera.Zip do
          src_path      <- Path.expand(src_raw_path, cwd_path),
          :ok           <- validate_within_tmpdir(cwd_path, tmpdir),
          :ok           <- validate_within_tmpdir(zip_path, tmpdir),
-         :ok           <- validate_within_tmpdir(src_path, tmpdir),
          :ok           <- reject_existing_file(cwd_path),
          :ok           <- reject_existing_dir(zip_path),
          :ok           <- ensure_dir_exists(zip_path, tmpdir),

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -127,9 +127,9 @@ defmodule Antikythera.Zip do
     end
   end
 
-  defunp validate_suffix(src_path :: v[String.t], cwd_path :: v[String.t]) :: :ok | {:error, tuple} do
+  defunp validate_suffix(src_path :: v[String.t], cwd_full_path :: v[String.t]) :: :ok | {:error, tuple} do
     suffixed = String.ends_with?(src_path, "/")
-    src_full_path = Path.expand(src_path, cwd_path)
+    src_full_path = Path.expand(src_path, cwd_full_path)
     if suffixed and !File.dir?(src_full_path) do
       {:error, {:not_dir, %{path: src_full_path}}}
     else

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -29,7 +29,7 @@ defmodule Antikythera.Zip do
   end
 
   defmodule NonTraversalPath do
-    use Croma.SubtypeOfString, pattern: ~R/\A([^.]|(?<!\.)\.(?!\.))+\z/
+    use Croma.SubtypeOfString, pattern: ~R/\A([^.\/]|((?<!\.)\.)|((?<!\A)\/))+\z/
   end
 
   @doc """

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -47,15 +47,15 @@ defmodule Antikythera.Zip do
             opts                :: v[list(opts)] \\ []) :: R.t(Path.t) do
     epool_id = extract_epool_id(context_or_epool_id)
     with {:ok, tmpdir} <- TmpdirTracker.get(epool_id),
-         :ok           <- reject_existing_dir(zip_raw_path),
-         :ok           <- validate_suffix(src_raw_path, cwd_path),
          cwd_path      <- Path.expand(cwd_raw_path),
          zip_path      <- Path.expand(zip_raw_path, cwd_path),
          src_path      <- Path.expand(src_raw_path, cwd_path),
          :ok           <- validate_within_tmpdir(zip_path, tmpdir),
          :ok           <- validate_within_tmpdir(src_path, tmpdir),
-         :ok           <- validate_path_exists(src_path),
+         :ok           <- reject_existing_dir(zip_path),
          :ok           <- ensure_dir_exists(zip_path, tmpdir),
+         :ok           <- validate_path_exists(src_path),
+         :ok           <- validate_suffix(src_raw_path, cwd_path),
          {:ok, args}   <- opts |> Map.new() |> extract_zip_args(),
          :ok           <- try_zip_cmd(args ++ [zip_raw_path, src_raw_path], cwd_path) do
       if zip_path |> Path.basename() |> String.contains?(".") do

--- a/lib/util/zip.ex
+++ b/lib/util/zip.ex
@@ -22,6 +22,10 @@ defmodule Antikythera.Zip do
     use Croma.SubtypeOfString, pattern: ~R/\A(?!.*\/\.{0,2}\z).*\z/
   end
 
+  defmodule NonTraversalPath do
+    use Croma.SubtypeOfString, pattern: ~R/\A([^.]|(?<!\.)\.(?!\.))+\z/
+  end
+
   @doc """
   Creates a ZIP file.
 
@@ -43,7 +47,7 @@ defmodule Antikythera.Zip do
   defun zip(context_or_epool_id :: v[EPoolId.t | Context.t],
             cwd_raw_path        :: v[String.t],
             zip_raw_path        :: v[FileName.t],
-            src_raw_path        :: v[String.t],
+            src_raw_path        :: v[NonTraversalPath.t],
             opts                :: v[list(opts)] \\ []) :: R.t(Path.t) do
     epool_id = extract_epool_id(context_or_epool_id)
     with {:ok, tmpdir} <- TmpdirTracker.get(epool_id),

--- a/mix.lock
+++ b/mix.lock
@@ -17,7 +17,7 @@
   "fast_xml": {:hex, :fast_xml, "1.1.34", "d76fc639d3607a44c4f0fb2dfdee1067b6c37b02b39706d8f067cb77eb2f6016", [:rebar3], [{:p1_utils, "1.0.13", [hex: :p1_utils, repo: "hexpm", optional: false]}], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
   "foretoken": {:hex, :foretoken, "0.3.0", "4305a2ee94886d9199ecc36dd2e5cef75795195b9b65c22e85ed656eea03f4ba", [:mix], [{:croma, "~> 0.9", [hex: :croma, repo: "hexpm", optional: false]}], "hexpm"},
-  "getopt": {:hex, :getopt, "0.8.2", "b17556db683000ba50370b16c0619df1337e7af7ecbf7d64fbf8d1d6bce3109b", [:rebar], [], "hexpm"},
+  "getopt": {:hex, :getopt, "0.8.2", "b17556db683000ba50370b16c0619df1337e7af7ecbf7d64fbf8d1d6bce3109b", [:rebar3], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.16.1", "e2130b25eebcbe02bb343b119a07ae2c7e28bd4b146c4a154da2ffb2b3507af2", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.14.3", "b5f6f5dcc4f1fba340762738759209e21914516df6be440d85772542d4a5e412", [:rebar3], [{:certifi, "2.4.2", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -40,7 +40,7 @@ defmodule Antikythera.ZipTest do
     end
   end
 
-  describe "Zip.zip/3" do
+  describe "Zip.zip/4" do
     test "returns path of resulting archive" do
       for(
         {dirs_to_create, files_to_create, src_path} <- [

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -40,7 +40,7 @@ defmodule Antikythera.ZipTest do
     end
   end
 
-  describe "Zip.zip/4" do
+  describe "Zip.zip/5" do
     test "returns path of resulting archive" do
       for(
         {dirs_to_create, files_to_create, src_path} <- [

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -112,12 +112,6 @@ defmodule Antikythera.ZipTest do
       assert Zip.zip(@context, invalid_cwd_path, @zip_path, @src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: invalid_cwd_path}}}
     end
 
-    test "returns error when src is outside tmpdir" do
-      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      invalid_src_path = "/another_dir" <> "/" <> @src_path
-      assert Zip.zip(@context, @tmpdir, @zip_path, invalid_src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: invalid_src_path}}}
-    end
-
     test "returns error when resulting archive is outside tmpdir" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       invalid_zip_path = "/another_dir" <> "/" <> @zip_path

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -11,18 +11,20 @@ defmodule Antikythera.ZipTest do
 
   @context Antikythera.Test.ConnHelper.make_conn().context
   @tmpdir   "/tmpdir"
-  @src_path "/tmpdir/src.txt"
-  @zip_path "/tmpdir/archive.zip"
+  @src_path "src.txt"
+  @zip_path "archive.zip"
+  @src_full_path @tmpdir <> "/" <> @src_path
+  @zip_full_path @tmpdir <> "/" <> @zip_path
 
   describe "Zip.FileName.valid?/1" do
     test "Exclude paths suffixed with /" do
-      assert Zip.FileName.valid?("/dir/file.ex")
-      assert Zip.FileName.valid?("/dir/file.")
-      refute Zip.FileName.valid?("/dir/file\n")
-      refute Zip.FileName.valid?("/dir/")
-      refute Zip.FileName.valid?("/dir/.")
-      refute Zip.FileName.valid?("/dir/..")
-      assert Zip.FileName.valid?("/dir/...")
+      assert Zip.FileName.valid?("file.ex")
+      assert Zip.FileName.valid?("file.")
+      refute Zip.FileName.valid?("file\n")
+      refute Zip.FileName.valid?("dir/")
+      refute Zip.FileName.valid?("dir/.")
+      refute Zip.FileName.valid?("dir/..")
+      assert Zip.FileName.valid?("dir/...")
     end
   end
 
@@ -30,118 +32,140 @@ defmodule Antikythera.ZipTest do
     test "returns path of resulting archive" do
       for(
         {dirs_to_create, files_to_create, src_path} <- [
-          {[],            ["/src.txt"],         "/src.txt"},
-          {["/src_dir/"], [],                   "/src_dir/"},
-          {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
+          {[],           ["src.txt"],         "src.txt"},
+          {["src_dir/"], [],                  "src_dir/"},
+          {["src_dir/"], ["src_dir/src.txt"], "src_dir/src.txt"},
         ],
         zip_path <- [
-          "/archive.zip",
-          "/zip_dir/archive.zip",
+          "archive.zip",
+          "zip_dir/archive.zip",
         ]
       ) do
         Tmpdir.make(@context, fn tmpdir ->
-          Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
-          Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
-          assert Zip.zip(@context, tmpdir <> zip_path, tmpdir <> src_path) == {:ok, tmpdir <> zip_path}
-          assert File.exists?(tmpdir <> zip_path)
+          zip_full_path = tmpdir <> "/" <> zip_path
+          Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> "/" <> &1))
+          Enum.each(files_to_create, &File.write!(tmpdir <> "/" <> &1, "text"))
+          assert Zip.zip(@context, tmpdir, zip_path, src_path) == {:ok, zip_full_path}
+          assert File.exists?(zip_full_path)
         end)
       end
     end
 
     test "returns path of resulting archive with .zip if no extension was assigned" do
       Tmpdir.make(@context, fn tmpdir ->
-        zip_path = tmpdir <> "/no_extension"
-        src_path = tmpdir <> "/src.txt"
-        File.write!(src_path, "text")
-        assert Zip.zip(@context, zip_path, src_path) == {:ok, zip_path <> ".zip"}
-        assert File.exists?(zip_path <> ".zip")
+        zip_path = "no_extension"
+        zip_full_path = tmpdir <> "/" <> zip_path <> ".zip"
+        src_full_path = tmpdir <> "/" <> @src_path
+        File.write!(src_full_path, "text")
+        assert Zip.zip(@context, tmpdir, zip_path, @src_path) == {:ok, zip_full_path}
+        assert File.exists?(zip_full_path)
       end)
     end
 
     test "returns path of resulting archive encrypted with password" do
       for(
         {dirs_to_create, files_to_create, src_path} <- [
-          {[],            ["/src.txt"],         "/src.txt"},
-          {["/src_dir/"], [],                   "/src_dir/"},
-          {["/src_dir/"], ["/src_dir/src.txt"], "/src_dir/src.txt"},
+          {[],           ["src.txt"],         "src.txt"},
+          {["src_dir/"], [],                  "src_dir/"},
+          {["src_dir/"], ["src_dir/src.txt"], "src_dir/src.txt"},
         ],
         zip_path <- [
-          "/archive.zip",
-          "/zip_dir/archive.zip",
+          "archive.zip",
+          "zip_dir/archive.zip",
         ]
       ) do
         Tmpdir.make(@context, fn tmpdir ->
-          Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> &1))
-          Enum.each(files_to_create, &File.write!(tmpdir <> &1, "text"))
-          assert Zip.zip(@context, tmpdir <> zip_path, tmpdir <> src_path, [encryption: true, password: "password"]) == {:ok, tmpdir <> zip_path}
-          assert File.exists?(tmpdir <> zip_path)
+          zip_full_path = tmpdir <> "/" <> zip_path
+          Enum.each(dirs_to_create, &File.mkdir_p!(tmpdir <> "/" <> &1))
+          Enum.each(files_to_create, &File.write!(tmpdir <> "/" <> &1, "text"))
+          assert Zip.zip(@context, tmpdir, zip_path, src_path, [encryption: true, password: "password"]) == {:ok, zip_full_path}
+          assert File.exists?(zip_full_path)
         end)
       end
     end
 
     test "returns error when a directory exists with same name as resulting archive" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      :meck.expect(File, :dir?, fn @zip_path -> true end)
-      assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:is_dir, %{path: @zip_path}}}
+      :meck.expect(File, :dir?, fn
+        @tmpdir        -> true
+        @zip_full_path -> true
+      end)
+      assert Zip.zip(@context, @tmpdir, @zip_path, @src_path) == {:error, {:is_dir, %{path: @zip_full_path}}}
     end
 
     test "returns error when input file name is suffixed with / while it is a file" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      src_path = "/tmpdir/src/"
-      :meck.expect(File, :dir?, fn _path -> false end)
-      assert Zip.zip(@context, @zip_path, src_path) == {:error, {:not_dir, %{path: src_path}}}
+      invalid_src_path = @src_path <> "/"
+      :meck.expect(File, :exists?, fn @src_full_path -> true end)
+      :meck.expect(File, :dir?, fn
+        @tmpdir        -> true
+        @zip_full_path -> false
+        @src_full_path -> false
+      end)
+      assert Zip.zip(@context, @tmpdir, @zip_path, invalid_src_path) == {:error, {:not_dir, %{path: @src_full_path}}}
     end
 
     test "returns error when tmpdir is not found" do
       :meck.expect(File, :exists?, fn _ -> flunk() end)
-      assert Zip.zip(@context, @zip_path, @src_path) == {:error, :not_found}
+      assert Zip.zip(@context, @tmpdir, @zip_path, @src_path) == {:error, :not_found}
     end
 
     test "returns error when src is outside tmpdir" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      src_path = "/another_dir/src.txt"
-      :meck.expect(File, :exists?, fn _ -> flunk() end)
-      assert Zip.zip(@context, @zip_path, src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: src_path}}}
+      invalid_src_path = "/another_dir" <> "/" <> @src_path
+      assert Zip.zip(@context, @tmpdir, @zip_path, invalid_src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: invalid_src_path}}}
     end
 
     test "returns error when resulting archive is outside tmpdir" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      zip_path = "/another_dir/archive.zip"
-      :meck.expect(File, :exists?, fn _ -> flunk() end)
-      assert Zip.zip(@context, zip_path, @src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: zip_path}}}
+      invalid_zip_path = "/another_dir" <> "/" <> @zip_path
+      assert Zip.zip(@context, @tmpdir, invalid_zip_path, @src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: invalid_zip_path}}}
     end
 
     test "returns error when src is not found" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      assert Zip.zip(@context, @zip_path, @src_path) == {:error, {:not_found, %{path: @src_path}}}
+      :meck.expect(File, :dir?, fn
+        @tmpdir        -> true
+        @zip_full_path -> false
+        @src_full_path -> false
+      end)
+      assert Zip.zip(@context, @tmpdir, @zip_path, @src_path) == {:error, {:not_found, %{path: @src_full_path}}}
     end
 
     test "returns error when zip path is through existing file name" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      zip_path = @src_path <> "/beneath_the_file.zip"
-      :meck.expect(File, :exists?, fn @src_path -> true end)
-      :meck.expect(File, :mkdir_p, fn @src_path -> {:error, :eexist} end)
-      assert Zip.zip(@context, zip_path, @src_path) == {:error, {:not_dir, %{path: zip_path}}}
+      invalid_zip_path = @src_path <> "/" <> "beneath_the_file.zip"
+      invalid_zip_full_path = @tmpdir <> "/" <> invalid_zip_path
+      :meck.expect(File, :dir?, fn
+        @tmpdir                -> true
+        ^invalid_zip_full_path -> false
+      end)
+      :meck.expect(File, :mkdir_p, fn @src_full_path -> {:error, :eexist} end)
+      assert Zip.zip(@context, @tmpdir, invalid_zip_path, @src_path) == {:error, {:not_dir, %{path: invalid_zip_full_path}}}
     end
 
     test "returns error when encryption is disabled and password exists" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
-      :meck.expect(File, :exists?, fn @src_path -> true end)
+      :meck.expect(File, :dir?, fn
+        @tmpdir        -> true
+        @zip_full_path -> false
+        @src_full_path -> false
+      end)
+      :meck.expect(File, :exists?, fn @src_full_path -> true end)
       [
         {[encryption: false, password: "password"], %{encryption: false, password: "password"}},
         {[encryption: true,  password: ""],         %{encryption: true,  password: ""}},
         {[encryption: true],                        %{encryption: true}},
       ] |> Enum.each(fn {invalid_args, expected} ->
-        assert Zip.zip(@context, @zip_path, @src_path, invalid_args) == {:error, {:argument_error, expected}}
+        assert Zip.zip(@context, @tmpdir, @zip_path, @src_path, invalid_args) == {:error, {:argument_error, expected}}
       end)
     end
 
     test "returns error when shell command fails" do
       Tmpdir.make(@context, fn tmpdir ->
-        zip_path = tmpdir <> "/archive.zip"
-        src_path = tmpdir <> "/src.txt"
-        :meck.expect(File, :exists?, fn ^src_path -> true end)
-        assert {:error, :shell_runtime_error} = Zip.zip(@context, zip_path, src_path)
+        src_full_path = tmpdir <> "/" <> @src_path
+        :meck.expect(File, :exists?, fn ^src_full_path -> true end)
+        assert {:error, :shell_runtime_error} = Zip.zip(@context, tmpdir, @zip_path, @src_path)
       end)
     end
   end

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -38,6 +38,11 @@ defmodule Antikythera.ZipTest do
       assert Zip.NonTraversalPath.valid?(".a.")
       refute Zip.NonTraversalPath.valid?("..a")
     end
+
+    test "Exclude absolute paths" do
+      refute Zip.NonTraversalPath.valid?("/")
+      refute Zip.NonTraversalPath.valid?("/a")
+    end
   end
 
   describe "Zip.zip/5" do

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -28,6 +28,18 @@ defmodule Antikythera.ZipTest do
     end
   end
 
+  describe "Zip.NonTraversalPath.valid?/1" do
+    test "Exclude paths with .." do
+      assert Zip.NonTraversalPath.valid?("file.txt")
+      assert Zip.NonTraversalPath.valid?(".")
+      refute Zip.NonTraversalPath.valid?("..")
+      refute Zip.NonTraversalPath.valid?("...")
+      refute Zip.NonTraversalPath.valid?("a..")
+      assert Zip.NonTraversalPath.valid?(".a.")
+      refute Zip.NonTraversalPath.valid?("..a")
+    end
+  end
+
   describe "Zip.zip/3" do
     test "returns path of resulting archive" do
       for(

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -113,7 +113,7 @@ defmodule Antikythera.ZipTest do
       assert Zip.zip(@context, @tmpdir, invalid_zip_path, @src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: invalid_zip_path}}}
     end
 
-    test "returns error when a directory exists with same name as resulting archive" do
+    test "returns error when zip_path is a directory" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       :meck.expect(File, :dir?, fn
         @tmpdir        -> true
@@ -134,7 +134,7 @@ defmodule Antikythera.ZipTest do
       assert Zip.zip(@context, @tmpdir, invalid_zip_path, @src_path) == {:error, {:not_dir, %{path: invalid_zip_full_path}}}
     end
 
-    test "returns error when input file name is suffixed with / while it is a file" do
+    test "returns error when src_path is a file suffixed with /" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       invalid_src_path = @src_path <> "/"
       :meck.expect(File, :exists?, fn @src_full_path -> true end)

--- a/test/lib/util/zip_test.exs
+++ b/test/lib/util/zip_test.exs
@@ -101,6 +101,12 @@ defmodule Antikythera.ZipTest do
       assert Zip.zip(@context, @tmpdir, @zip_path, @src_path) == {:error, :not_found}
     end
 
+    test "returns error when cwd is outside tmpdir" do
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
+      invalid_cwd_path = "/another_dir"
+      assert Zip.zip(@context, invalid_cwd_path, @zip_path, @src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: invalid_cwd_path}}}
+    end
+
     test "returns error when src is outside tmpdir" do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       invalid_src_path = "/another_dir" <> "/" <> @src_path
@@ -111,6 +117,12 @@ defmodule Antikythera.ZipTest do
       :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
       invalid_zip_path = "/another_dir" <> "/" <> @zip_path
       assert Zip.zip(@context, @tmpdir, invalid_zip_path, @src_path) == {:error, {:permission_denied, %{tmpdir: @tmpdir, path: invalid_zip_path}}}
+    end
+
+    test "returns error when the cwd is not a directory" do
+      :meck.expect(TmpdirTracker, :get, fn _ -> {:ok, @tmpdir} end)
+      :meck.expect(File, :dir?, fn @tmpdir -> false end)
+      assert Zip.zip(@context, @tmpdir, @zip_path, @src_path) == {:error, {:not_dir, %{path: @tmpdir}}}
     end
 
     test "returns error when zip_path is a directory" do


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/177185

Enabled using relative path by passing `cwd` to `Zip.zip` (now arity 5),
then turned into `:cd` option in `System.cmd/3`.
Otherwise, when absolute paths are used, you will have a zip file *including directory structure*.

I appreciate your suggestions.