### PR TITLE
[179864] fix credo error: large abc size

### DIFF
--- a/core/async_job/queue.ex
+++ b/core/async_job/queue.ex
@@ -54,13 +54,15 @@ defmodule AntikytheraCore.AsyncJob.Queue do
   @impl true
   defun new() :: t do
     set = :gb_sets.empty()
-    %__MODULE__{jobs:              %{},
-                index_waiting:     set,
-                index_runnable:    set,
-                index_running:     set,
-                brokers_waiting:   [],
-                brokers_to_notify: [],
-                abandoned_jobs:    []}
+    %__MODULE__{
+      jobs:              %{},
+      index_waiting:     set,
+      index_runnable:    set,
+      index_running:     set,
+      brokers_waiting:   [],
+      brokers_to_notify: [],
+      abandoned_jobs:    [],
+    }
   end
 
   @impl true
@@ -116,7 +118,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     end
   end
 
-  defp move_job_running_too_long(q, target_job_info, _now_millis, _threshold_time) when is_nil(target_job_info), do: q
+  defp move_job_running_too_long(q, nil = _target_job_info, _now_millis, _threshold_time), do: q
   defp move_job_running_too_long(%__MODULE__{jobs:          jobs,
                                              index_waiting: index_waiting} = q,
                                  {{_, job_id}, _} = target_job_info,
@@ -163,7 +165,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     move_now_runnable_job(q, target_job_info, now_millis)
   end
 
-  defp move_now_runnable_job(q, target_job_info, _now_millis) when is_nil(target_job_info), do: q
+  defp move_now_runnable_job(q, nil = _target_job_info, _now_millis), do: q
   defp move_now_runnable_job(%__MODULE__{jobs:            jobs,
                                          index_runnable:  index_runnable,
                                          brokers_waiting: brokers_waiting} = q,

--- a/core/async_job/queue.ex
+++ b/core/async_job/queue.ex
@@ -74,7 +74,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
       {{:unlock_for_retry, job_key}           , now_millis} -> {{:ok, unlock_for_retry(q1, job_key, now_millis)}, now_millis}
       {{:remove_broker_from_waiting_list, pid}, now_millis} -> {{:ok, remove_broker(q1, pid)},                    now_millis}
       {{:cancel, job_id}                      , now_millis} -> {cancel_job(q1, job_id),                           now_millis}
-      {:get_metrics                           , now_millis} -> { {metrics(q1), q1},                               now_millis}
+      {:get_metrics                           , now_millis} -> {{metrics(q1), q1},                                now_millis}
       _                                                     -> {{:ok, q1}} # failsafe: not to crash on unexpected command
     end
     |> case do

--- a/core/async_job/queue.ex
+++ b/core/async_job/queue.ex
@@ -66,29 +66,18 @@ defmodule AntikytheraCore.AsyncJob.Queue do
   @impl true
   defun command(q1 :: v[t], cmd :: RVData.command_arg) :: {RVData.command_ret, t} do
     case cmd do
-      {{:add, job_key, job}                   , now_millis} ->
-        insert(q1, job_key, job)
-        |> maintain_invariants_and_return(now_millis)
-      {{:fetch, broker}                       , now_millis} ->
-        fetch(q1, broker, now_millis)
-        |> maintain_invariants_and_return(now_millis)
-      {{:remove_locked, job_key}              , now_millis} ->
-        {:ok, remove_locked(q1, job_key, now_millis)}
-        |> maintain_invariants_and_return(now_millis)
-      {{:unlock_for_retry, job_key}           , now_millis} ->
-        {:ok, unlock_for_retry(q1, job_key, now_millis)}
-        |> maintain_invariants_and_return(now_millis)
-      {{:remove_broker_from_waiting_list, pid}, now_millis} ->
-        {:ok, remove_broker(q1, pid)}
-        |> maintain_invariants_and_return(now_millis)
-      {{:cancel, job_id}                      , now_millis} ->
-        cancel_job(q1, job_id)
-        |> maintain_invariants_and_return(now_millis)
-      {:get_metrics                           , now_millis} ->
-        {metrics(q1), q1}
-        |> maintain_invariants_and_return(now_millis)
-      _                                                     ->
-        {:ok, q1} # failsafe: not to crash on unexpected command
+      {{:add, job_key, job}                   , now_millis} -> {insert(q1, job_key, job),                         now_millis}
+      {{:fetch, broker}                       , now_millis} -> {fetch(q1, broker, now_millis),                    now_millis}
+      {{:remove_locked, job_key}              , now_millis} -> {{:ok, remove_locked(q1, job_key, now_millis)},    now_millis}
+      {{:unlock_for_retry, job_key}           , now_millis} -> {{:ok, unlock_for_retry(q1, job_key, now_millis)}, now_millis}
+      {{:remove_broker_from_waiting_list, pid}, now_millis} -> {{:ok, remove_broker(q1, pid)},                    now_millis}
+      {{:cancel, job_id}                      , now_millis} -> {cancel_job(q1, job_id),                           now_millis}
+      {:get_metrics                           , now_millis} -> { {metrics(q1), q1},                               now_millis}
+      _                                                     -> {{:ok, q1}} # failsafe: not to crash on unexpected command
+    end
+    |> case do
+      {first_arg, now_millis} -> maintain_invariants_and_return(first_arg, now_millis)
+      {failsafe}              -> failsafe
     end
   end
 
@@ -106,10 +95,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     %__MODULE__{q | abandoned_jobs: []}
     |> move_jobs_running_too_long(now_millis)
   end
-  defp move_jobs_running_too_long(%__MODULE__{jobs:           _,
-                                              index_waiting:  _,
-                                              index_running:  index_running,
-                                              abandoned_jobs: _} = q,
+  defp move_jobs_running_too_long(%__MODULE__{index_running: index_running} = q,
                                   now_millis) do
     threshold_time = now_millis - MaxDuration.max()
     target_job_info = take_smallest_with_earlier_timestamp(index_running, threshold_time)
@@ -131,10 +117,8 @@ defmodule AntikytheraCore.AsyncJob.Queue do
   end
 
   defp move_job_running_too_long(q, target_job_info, _now_millis, _threshold_time) when is_nil(target_job_info), do: q
-  defp move_job_running_too_long(%__MODULE__{jobs:           jobs,
-                                             index_waiting:  index_waiting,
-                                             index_running:  _,
-                                             abandoned_jobs: _} = q,
+  defp move_job_running_too_long(%__MODULE__{jobs:          jobs,
+                                             index_waiting: index_waiting} = q,
                                  {{_, job_id}, _} = target_job_info,
                                  now_millis,
                                  threshold_time) do
@@ -149,8 +133,6 @@ defmodule AntikytheraCore.AsyncJob.Queue do
   end
 
   defp abandon_job(%__MODULE__{jobs:           jobs,
-                               index_waiting:  _,
-                               index_running:  _,
                                abandoned_jobs: abandoned_jobs} = q,
                    {{_, job_id}, index_running2} = _target_job_info,
                    job) do
@@ -159,10 +141,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     %__MODULE__{q | jobs: jobs2, index_running: index_running2, abandoned_jobs: abandoned_jobs2}
   end
 
-  defp attempt_job(%__MODULE__{jobs:           jobs,
-                               index_waiting:  _,
-                               index_running:  _,
-                               abandoned_jobs: _} = q,
+  defp attempt_job(%__MODULE__{jobs: jobs} = q,
                    {{_, job_id} = job_key, index_running2} = _target_job_info,
                    job,
                    time,
@@ -178,22 +157,16 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     %__MODULE__{q | brokers_to_notify: []}
     |> move_now_runnable_jobs_impl(now_millis)
   end
-  defp move_now_runnable_jobs_impl(%__MODULE__{jobs:              _,
-                                               index_waiting:     index_waiting,
-                                               index_runnable:    _,
-                                               brokers_waiting:   _,
-                                               brokers_to_notify: _} = q,
+  defp move_now_runnable_jobs_impl(%__MODULE__{index_waiting: index_waiting} = q,
                                    now_millis) do
     target_job_info = take_smallest_with_earlier_timestamp(index_waiting, now_millis)
     move_now_runnable_job(q, target_job_info, now_millis)
   end
 
   defp move_now_runnable_job(q, target_job_info, _now_millis) when is_nil(target_job_info), do: q
-  defp move_now_runnable_job(%__MODULE__{jobs:              jobs,
-                                         index_waiting:     _,
-                                         index_runnable:    index_runnable,
-                                         brokers_waiting:   brokers_waiting,
-                                         brokers_to_notify: _} = q,
+  defp move_now_runnable_job(%__MODULE__{jobs:            jobs,
+                                         index_runnable:  index_runnable,
+                                         brokers_waiting: brokers_waiting} = q,
                                   {{_, job_id} = job_key, index_waiting2} = _target_job_info,
                                   now_millis) do
     jobs2 = Map.update!(jobs, job_id, fn {j, t, :waiting} -> {j, t, :runnable} end)
@@ -204,11 +177,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
   end
 
   defp move_first_waiting_broker(q, [] = _brokers_waiting), do: q
-  defp move_first_waiting_broker(%__MODULE__{jobs:              _,
-                                             index_waiting:     _,
-                                             index_runnable:    _,
-                                             brokers_waiting:   _,
-                                             brokers_to_notify: brokers_to_notify} = q,
+  defp move_first_waiting_broker(%__MODULE__{brokers_to_notify: brokers_to_notify} = q,
                                  [b | bs] = _brokers_waiting) do
     %__MODULE__{q | brokers_waiting: bs, brokers_to_notify: [b | brokers_to_notify]}
   end
@@ -230,8 +199,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     end
   end
 
-  defp fetch(%__MODULE__{index_waiting:   _,
-                         index_runnable:  index_runnable,
+  defp fetch(%__MODULE__{index_runnable:  index_runnable,
                          brokers_waiting: bs_waiting} = q,
              broker,
              now_millis) do
@@ -245,9 +213,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     end
   end
 
-  defp fetch_waiting_job(%__MODULE__{index_waiting:   index_waiting,
-                                     index_runnable:  _,
-                                     brokers_waiting: _} = q,
+  defp fetch_waiting_job(%__MODULE__{index_waiting: index_waiting} = q,
                          bs_waiting,
                          broker,
                          now_millis) do
@@ -329,10 +295,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     %__MODULE__{q | brokers_waiting: remove_brokers_by_node(brokers, pid)}
   end
 
-  defp cancel_job(%__MODULE__{jobs:           jobs,
-                              index_waiting:  _,
-                              index_runnable: _,
-                              index_running:  _} = q,
+  defp cancel_job(%__MODULE__{jobs: jobs} = q,
                   job_id) do
     case Map.pop(jobs, job_id) do
       {nil, _}                  -> {{:error, :not_found}, q}
@@ -343,8 +306,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     end
   end
 
-  defp cancel_job_impl(%__MODULE__{jobs:           _,
-                                   index_waiting:  index_waiting,
+  defp cancel_job_impl(%__MODULE__{index_waiting:  index_waiting,
                                    index_runnable: index_runnable,
                                    index_running:  index_running} = q,
                        state,

--- a/core/async_job/queue.ex
+++ b/core/async_job/queue.ex
@@ -124,12 +124,12 @@ defmodule AntikytheraCore.AsyncJob.Queue do
                                  {{_, job_id}, _} = target_job_info,
                                  now_millis,
                                  threshold_time) do
-    {j1, t, :running} = Map.fetch!(jobs, job_id)
-    case j1.remaining_attempts do
+    {job, t, :running} = Map.fetch!(jobs, job_id)
+    case job.remaining_attempts do
       1 ->
-        abandon_job(q, target_job_info, j1) |> requeue_if_recurring(j1, job_id, now_millis)
+        abandon_job(q, target_job_info, job) |> requeue_if_recurring(job, job_id, now_millis)
       remaining ->
-        attempt_job(q, target_job_info, j1, t, remaining, index_waiting)
+        attempt_job(q, target_job_info, job, t, remaining, index_waiting)
     end
     |> move_jobs_running_too_long(threshold_time)
   end

--- a/core/async_job/queue.ex
+++ b/core/async_job/queue.ex
@@ -169,8 +169,8 @@ defmodule AntikytheraCore.AsyncJob.Queue do
   defp move_now_runnable_job(%__MODULE__{jobs:            jobs,
                                          index_runnable:  index_runnable,
                                          brokers_waiting: brokers_waiting} = q,
-                                  {{_, job_id} = job_key, index_waiting2} = _target_job_info,
-                                  now_millis) do
+                             {{_, job_id} = job_key, index_waiting2} = _target_job_info,
+                             now_millis) do
     jobs2 = Map.update!(jobs, job_id, fn {j, t, :waiting} -> {j, t, :runnable} end)
     index_runnable2 = :gb_sets.add(job_key, index_runnable)
     q2 = %__MODULE__{q | jobs: jobs2, index_waiting: index_waiting2, index_runnable: index_runnable2}

--- a/core/async_job/queue.ex
+++ b/core/async_job/queue.ex
@@ -118,7 +118,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     end
   end
 
-  defp move_job_running_too_long(q, nil = _target_job_info, _now_millis, _threshold_time), do: q
+  defp move_job_running_too_long(q, nil, _now_millis, _threshold_time), do: q
   defp move_job_running_too_long(%__MODULE__{jobs:          jobs,
                                              index_waiting: index_waiting} = q,
                                  {{_, job_id}, _} = target_job_info,
@@ -165,7 +165,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     move_now_runnable_job(q, target_job_info, now_millis)
   end
 
-  defp move_now_runnable_job(q, nil = _target_job_info, _now_millis), do: q
+  defp move_now_runnable_job(q, nil, _now_millis), do: q
   defp move_now_runnable_job(%__MODULE__{jobs:            jobs,
                                          index_runnable:  index_runnable,
                                          brokers_waiting: brokers_waiting} = q,
@@ -178,7 +178,7 @@ defmodule AntikytheraCore.AsyncJob.Queue do
     |> move_now_runnable_jobs_impl(now_millis)
   end
 
-  defp move_first_waiting_broker(q, [] = _brokers_waiting), do: q
+  defp move_first_waiting_broker(q, []), do: q
   defp move_first_waiting_broker(%__MODULE__{brokers_to_notify: brokers_to_notify} = q,
                                  [b | bs] = _brokers_waiting) do
     %__MODULE__{q | brokers_waiting: bs, brokers_to_notify: [b | brokers_to_notify]}

--- a/lib/mix/gear_static_analysis.ex
+++ b/lib/mix/gear_static_analysis.ex
@@ -25,20 +25,36 @@ defmodule Mix.Tasks.Compile.GearStaticAnalysis do
   end
 
   defp find_issues_in_file(ex_file_path) do
+    find_issue = make_function_to_find_issue(ex_file_path)
     File.read!(ex_file_path)
     |> Code.string_to_quoted!()
-    |> Macro.prewalk([], fn
-      ({:defmodule, meta, [{:__aliases__, _, atoms}, [do: body]]}, acc) ->
-        {issue_or_nil, tool?} = check_toplevel_module_name(Module.concat(atoms), meta, ex_file_path)
-        check_module_body(body, List.wrap(issue_or_nil) ++ acc, ex_file_path, tool?)
-      ({:defimpl, meta, [{:__aliases__, _, protocol_atoms}, [for: {:__aliases__, _, mod_atoms}], [do: body]]}, acc) ->
-        issue_or_nil = check_defimpl(Module.concat(protocol_atoms), Module.concat(mod_atoms), meta, ex_file_path)
-        check_module_body(body, List.wrap(issue_or_nil) ++ acc, ex_file_path, false)
-      (n, acc) ->
-        {n, acc}
-    end)
+    |> Macro.prewalk([], find_issue)
     |> elem(1)
     |> Enum.reverse()
+  end
+
+  defp make_function_to_find_issue(ex_file_path) do
+    fn
+      ({:defmodule, meta, [{:__aliases__, _, atoms}, [do: body]]}, acc) ->
+        find_issue_in_module(meta, atoms, body, acc, ex_file_path)
+      ({:defimpl, meta, [{:__aliases__, _, protocol_atoms}, [for: {:__aliases__, _, mod_atoms}], [do: body]]}, acc) ->
+        find_issue_in_impl(meta, protocol_atoms, mod_atoms, body, acc, ex_file_path)
+      (n, acc) ->
+        {n, acc}
+    end
+  end
+
+  defp find_issue_in_module(meta, atoms, body, acc, ex_file_path) do
+    concated_atoms = Module.safe_concat(atoms)
+    {issue_or_nil, tool?} = check_toplevel_module_name(concated_atoms, meta, ex_file_path)
+    check_module_body(body, List.wrap(issue_or_nil) ++ acc, ex_file_path, tool?)
+  end
+
+  defp find_issue_in_impl(meta, protocol_atoms, mod_atoms, body, acc, ex_file_path) do
+    concated_protocol_atoms = Module.safe_concat(protocol_atoms)
+    concated_mod_atoms = Module.safe_concat(mod_atoms)
+    issue_or_nil = check_defimpl(concated_protocol_atoms, concated_mod_atoms, meta, ex_file_path)
+    check_module_body(body, List.wrap(issue_or_nil) ++ acc, ex_file_path, false)
   end
 
   defp check_toplevel_module_name(mod, meta, file) do
@@ -75,74 +91,99 @@ defmodule Mix.Tasks.Compile.GearStaticAnalysis do
     {nil, issues ++ acc} # don't walk into the module body further by returning `nil`
   end
 
-  defp check_ast_node(n, file, tool?) do
-    case n do
-      {:defimpl, meta, [{:__aliases__, _, protocol_atoms}, [for: {:__aliases__, _, mod_atoms}], [do: _block]]} ->
-        # We don't have to check `defimpl` without `for:`, as the enclosing module's name is enforced to be properly prefixed by gear name.
-        check_defimpl(Module.concat(protocol_atoms), Module.concat(mod_atoms), meta, file)
-      {:use, meta, [{:__aliases__, _, atoms} | kw]} ->
-        with_concatenated_module_atom(atoms, fn mod ->
-          check_use_within_module(mod, kw, meta, file, tool?)
-        end)
-      {{:., _, [{:__aliases__, _, atoms}, fun]}, meta, args} ->
-        with_concatenated_module_atom(atoms, fn mod ->
-          check_remote_call(mod, fun, args, meta, file, tool?)
-        end)
-      {{:., _, [erlang_mod, fun]}, meta, args} ->
-        check_remote_call(erlang_mod, fun, args, meta, file, tool?)
-      {:__aliases__, meta, atoms} ->
-        with_concatenated_module_atom(atoms, fn mod ->
-          check_module(mod, meta, file, tool?)
-        end)
-      {fun, meta, args} when is_atom(fun) and is_list(args) ->
-        check_local_call(fun, args, meta, file, tool?)
-      atom when is_atom(atom) ->
-        check_atom(atom, file)
-      _ ->
-        nil
-    end
+  defp check_ast_node({:defimpl, meta, [{:__aliases__, _, protocol_atoms},
+                                        [for: {:__aliases__, _, mod_atoms}],
+                                        [do: _block]]},
+                      file,
+                      _tool?) do
+    concated_protocol_atoms = Module.safe_concat(protocol_atoms)
+    concated_mod_atoms = Module.safe_concat(mod_atoms)
+    # We don't have to check `defimpl` without `for:`, as the enclosing module's name is enforced to be properly prefixed by gear name.
+    check_defimpl(concated_protocol_atoms, concated_mod_atoms, meta, file)
   end
+
+  defp check_ast_node({:use, meta, [{:__aliases__, _, atoms} | kw]}, file, _tool?) do
+    with_concatenated_module_atom(atoms, fn mod ->
+      check_use_within_module(mod, kw, meta, file)
+    end)
+  end
+
+  defp check_ast_node({{:., _, [{:__aliases__, _, atoms}, fun]}, meta, args}, file, false = _tool?) do
+    with_concatenated_module_atom(atoms, fn mod ->
+      check_remote_call(mod, fun, args, meta, file)
+    end)
+  end
+
+  defp check_ast_node({{:., _, [erlang_mod, fun]}, meta, args}, file, false = _tool?) do
+    check_remote_call(erlang_mod, fun, args, meta, file)
+  end
+
+  defp check_ast_node({:__aliases__, meta, atoms}, file, tool?) do
+    with_concatenated_module_atom(atoms, fn mod ->
+      check_module(mod, meta, file, tool?)
+    end)
+  end
+
+  defp check_ast_node({fun, meta, args}, file, _tool?) when is_atom(fun) and is_list(args) do
+    check_local_call(fun, args, meta, file)
+  end
+
+  defp check_ast_node(atom, file, _tool?) when is_atom(atom) do
+    check_atom(atom, file)
+  end
+
+  defp check_ast_node(_, _file, _tool?), do: nil
 
   defp with_concatenated_module_atom(atoms, f) do
     # exclude module aliases such as `__MODULE__.Foo` by returning `nil`
     if Enum.all?(atoms, &is_atom/1) do
-      f.(Module.concat(atoms))
+      f.(Module.safe_concat(atoms))
     end
   end
 
-  defp check_use_within_module(mod, _kw, _meta, file, _tool?) do
-    cond do
-      mod == Gettext ->
-        {:error, file, [], "directly invoking `use Gettext` is not allowed (`use Antikythera.Gettext` instead)"}
-      true ->
-        nil
+  defp check_use_within_module(mod, _kw, _meta, file) do
+    if mod == Gettext do
+      {:error, file, [], "directly invoking `use Gettext` is not allowed (`use Antikythera.Gettext` instead)"}
     end
   end
 
-  defp check_remote_call(mod, fun, args, meta, file, tool?) do
+  defp check_remote_call(System, fun, _args, meta, file) when fun in [:halt, :stop] do
+    {:error, file, meta, "disturbing execution of ErlangVM is strictly prohibited"}
+  end
+
+  defp check_remote_call(:erlang, :halt = _fun, _args, meta, file) do
+    {:error, file, meta, "disturbing execution of ErlangVM is strictly prohibited"}
+  end
+
+  defp check_remote_call(:init, _fun, _args, meta, file) do
+    {:error, file, meta, "disturbing execution of ErlangVM is strictly prohibited"}
+  end
+
+  defp check_remote_call(IO, fun, args, meta, file) do
+    if fun in [:inspect, :puts, :write] and writing_to_stdout?(args) do
+      severity = if Mix.env() == :prod, do: :error, else: :warning
+      {severity, file, meta, "writing to STDOUT/STDERR is not allowed in prod environment (use each gear's logger instead)"}
+    end
+  end
+
+  defp check_remote_call(mod, fun, _args, meta, file) when mod in [Process, Task, Agent] do
+    if spawning_a_new_process?(Atom.to_string(fun)) do
+      {:error, file, meta, "spawning processes in gear's code is prohibited"}
+    end
+  end
+
+  defp check_remote_call(:os, :cmd = _fun, _args, meta, file) do
+    {:error, file, meta, "calling :os.cmd/1 in gear's code is prohibited"}
+  end
+
+  defp check_remote_call(System, :cmd = _fun, _args, meta, file) do
     use_internals? = use_antikythera_internal_modules?()
-    if !tool? do
-      cond do
-        mod == System and fun in [:halt, :stop] ->
-          {:error, file, meta, "disturbing execution of ErlangVM is strictly prohibited"}
-        mod == :erlang and fun == :halt ->
-          {:error, file, meta, "disturbing execution of ErlangVM is strictly prohibited"}
-        mod == :init ->
-          {:error, file, meta, "disturbing execution of ErlangVM is strictly prohibited"}
-        mod == IO and fun in [:inspect, :puts, :write] and writing_to_stdout?(args) ->
-          severity = if Mix.env() == :prod, do: :error, else: :warning
-          {severity, file, meta, "writing to STDOUT/STDERR is not allowed in prod environment (use each gear's logger instead)"}
-        mod in [Process, Task, Agent] and spawning_a_new_process?(Atom.to_string(fun)) ->
-          {:error, file, meta, "spawning processes in gear's code is prohibited"}
-        mod == :os and fun == :cmd ->
-          {:error, file, meta, "calling :os.cmd/1 in gear's code is prohibited"}
-        !use_internals? and mod == System and fun == :cmd ->
-          {:error, file, meta, "calling System.cmd/3 in gear's code is prohibited"}
-        true ->
-          nil
-      end
+    if !use_internals? do
+      {:error, file, meta, "calling System.cmd/3 in gear's code is prohibited"}
     end
   end
+
+  defp check_remote_call(_mod, _fun, _args, _meta, _file), do: nil
 
   defp writing_to_stdout?([_]         ), do: true
   defp writing_to_stdout?([:stdio | _]), do: true
@@ -153,11 +194,9 @@ defmodule Mix.Tasks.Compile.GearStaticAnalysis do
   defp spawning_a_new_process?("async" <> _), do: true
   defp spawning_a_new_process?(_           ), do: false
 
-  defp check_local_call(fun, _args, meta, file, _tool?) do
-    cond do
-      Atom.to_string(fun) |> String.starts_with?("spawn") ->
-        {:error, file, meta, "spawning processes in gear's code is prohibited"}
-      true -> nil
+  defp check_local_call(fun, _args, meta, file) do
+    if Atom.to_string(fun) |> String.starts_with?("spawn") do
+      {:error, file, meta, "spawning processes in gear's code is prohibited"}
     end
   end
 
@@ -229,10 +268,7 @@ defmodule Mix.Tasks.Compile.GearStaticAnalysis do
   defp report(issues) do
     mod_name = Module.split(__MODULE__) |> List.last()
     prefix   = "[#{mod_name}]"
-    Enum.each(issues, fn
-      {:warning, file, meta, msg} -> IO.puts("#{prefix} #{file}:#{meta[:line]} WARNING #{msg}")
-      {:error  , file, meta, msg} -> IO.puts(IO.ANSI.red() <> "#{prefix} #{file}:#{meta[:line]} ERROR #{msg}" <> IO.ANSI.reset())
-    end)
+    print_issues(issues, prefix)
     {warnings, errors} = Enum.split_with(issues, &match?({:warning, _, _, _}, &1))
     n_warnings = length(warnings)
     n_errors   = length(errors)
@@ -241,5 +277,12 @@ defmodule Mix.Tasks.Compile.GearStaticAnalysis do
       n_warnings > 0 -> IO.puts("#{prefix} Found #{n_warnings} warnings.")
       true           -> :ok
     end
+  end
+
+  defp print_issues(issues, prefix) do
+    Enum.each(issues, fn
+      {:warning, file, meta, msg} -> IO.puts("#{prefix} #{file}:#{meta[:line]} WARNING #{msg}")
+      {:error  , file, meta, msg} -> IO.puts(IO.ANSI.red() <> "#{prefix} #{file}:#{meta[:line]} ERROR #{msg}" <> IO.ANSI.reset())
+    end)
   end
 end

--- a/lib/web/template/precompiler.ex
+++ b/lib/web/template/precompiler.ex
@@ -71,16 +71,27 @@ defmodule Antikythera.TemplatePrecompiler do
     for {var_name, count} <- free_vars_map, count > 0, do: var_name
   end
 
-  defp extract_vars_in_ast_node(t, {acc_free, acc_bound} = acc) do
-    case t do
-      {:::, _, [_, {:binary, _, nil}]}  -> {Map.update(acc_free, :binary, -1, &(&1 - 1)), acc_bound} # cancel count of type expr in AST of string interpolation
-      {:= , _, [lhs, _rhs]}             -> {acc_free, MapSet.union(collect_vars(lhs), acc_bound)}
-      {:<-, _, [lhs, _rhs]}             -> {acc_free, MapSet.union(collect_vars(lhs), acc_bound)}
-      {:->, _, [[lhs | _guards], _rhs]} -> {acc_free, MapSet.union(collect_vars(lhs), acc_bound)}
-      {name, _, nil}                    -> if name in acc_bound, do: acc, else: {Map.update(acc_free, name, 1, &(&1 + 1)), acc_bound}
-      _                                 -> acc
-    end
+  defp extract_vars_in_ast_node({:::, _, [_, {:binary, _, nil}]}, {acc_free, acc_bound} = _acc) do
+    {Map.update(acc_free, :binary, -1, &(&1 - 1)), acc_bound} # cancel count of type expr in AST of string interpolation
   end
+
+  defp extract_vars_in_ast_node({:=, _, [lhs, _rhs]}, {acc_free, acc_bound} = _acc) do
+    {acc_free, MapSet.union(collect_vars(lhs), acc_bound)}
+  end
+
+  defp extract_vars_in_ast_node({:<-, _, [lhs, _rhs]}, {acc_free, acc_bound} = _acc) do
+    {acc_free, MapSet.union(collect_vars(lhs), acc_bound)}
+  end
+
+  defp extract_vars_in_ast_node({:->, _, [[lhs | _guards], _rhs]}, {acc_free, acc_bound} = _acc) do
+    {acc_free, MapSet.union(collect_vars(lhs), acc_bound)}
+  end
+
+  defp extract_vars_in_ast_node({name, _, nil}, {acc_free, acc_bound} = acc) do
+    if name in acc_bound, do: acc, else: {Map.update(acc_free, name, 1, &(&1 + 1)), acc_bound}
+  end
+
+  defp extract_vars_in_ast_node(_, acc), do: acc
 
   defunp collect_vars(q :: Macro.t) :: MapSet.t do
     MacroUtil.prewalk_accumulate(q, [], fn(t, acc) ->


### PR DESCRIPTION
ticket: https://acsmine.tok.access-company.com/redmine/issues/179864

This commit passes `mix credo --strict` for the below three files:

* `lib/mix/gear_static_analysis.ex`
* `lib/web/template/precompiler.ex`
* `core/async_job/queue.ex`

Most of the changes are deconstruction of `cond` and `case` in a function by defining same-name functions distinguished by pattern-matching (like overloading); These changes are for reducing ABC size of functions.