### PR TITLE
[179864] Fix credo error: Function is too complex

### DIFF
--- a/core/metrics/aggregate_strategy/time_distribution.ex
+++ b/core/metrics/aggregate_strategy/time_distribution.ex
@@ -41,13 +41,17 @@ defmodule Strategy.TimeDistribution do
   end
 
   defp find_nth_largest(index, [pivot | values]) do
-    {larger, smaller, larger_count} = Enum.reduce(values, {[], [], 0}, fn(v, {larger, smaller, count}) ->
-      if v > pivot, do: {[v | larger], smaller, count + 1}, else: {larger, [v | smaller], count}
-    end)
+    {larger, smaller, larger_count} = divide_by_pivot(values, pivot)
     cond do
       index <  larger_count -> find_nth_largest(index, larger)
       index == larger_count -> pivot
       true                  -> find_nth_largest(index - larger_count - 1, smaller)
     end
+  end
+
+  defp divide_by_pivot(values, pivot) do
+    Enum.reduce(values, {[], [], 0}, fn(v, {larger, smaller, count}) ->
+      if v > pivot, do: {[v | larger], smaller, count + 1}, else: {larger, [v | smaller], count}
+    end)
   end
 end

--- a/core/mix/generate_release.ex
+++ b/core/mix/generate_release.ex
@@ -71,7 +71,8 @@ defmodule Mix.Tasks.AntikytheraCore.GenerateRelease do
       :ok = Mix.Tasks.Compile.App.run(["--force"])
     rescue
       File.Error ->
-        # Directory for <antikythera_instance>.app does not exist, i.e. the antikythera instance is not yet compiled; run the normal compilation.
+        # Directory for <antikythera_instance>.app does not exist,
+        # i.e. the antikythera instance is not yet compiled; run the normal compilation.
         Mix.Tasks.Compile.run([])
     end
   end
@@ -185,6 +186,10 @@ defmodule Mix.Tasks.AntikytheraCore.GenerateRelease do
     instance_otp_app = {release_name, rel_version, Path.join([Mix.Project.build_path(), "lib", release_name_str])}
     current_otp_apps = [instance_otp_app | current_deps]
     prev_otp_apps = read_rel_file(release_name_str, from_rel_version, release_output_dir)
+    generate_appup_files_impl(release_name_str, current_otp_apps, prev_otp_apps, release_output_dir)
+  end
+
+  defp generate_appup_files_impl(release_name_str, current_otp_apps, prev_otp_apps, release_output_dir) do
     Enum.each(current_otp_apps, fn {name, version, dir} ->
       case prev_otp_apps[name] do
         nil          -> :ok

--- a/lib/util/time.ex
+++ b/lib/util/time.ex
@@ -116,12 +116,16 @@ defmodule Antikythera.Time do
 
   defp extract_timezone_offset_minutes(str) do
     case str do
-      <<"+", h :: binary-size(2), ":", m :: binary-size(2)>> ->   String.to_integer(h) * 60 + String.to_integer(m)
-      <<"+", h :: binary-size(2),      m :: binary-size(2)>> ->   String.to_integer(h) * 60 + String.to_integer(m)
-      <<"-", h :: binary-size(2), ":", m :: binary-size(2)>> -> -(String.to_integer(h) * 60 + String.to_integer(m))
-      <<"-", h :: binary-size(2),      m :: binary-size(2)>> -> -(String.to_integer(h) * 60 + String.to_integer(m))
+      <<"+", h :: binary-size(2), ":", m :: binary-size(2)>> ->  convert_to_minutes(h, m)
+      <<"+", h :: binary-size(2),      m :: binary-size(2)>> ->  convert_to_minutes(h, m)
+      <<"-", h :: binary-size(2), ":", m :: binary-size(2)>> -> -convert_to_minutes(h, m)
+      <<"-", h :: binary-size(2),      m :: binary-size(2)>> -> -convert_to_minutes(h, m)
       "Z"                                                    ->   0
     end
+  end
+
+  defp convert_to_minutes(hour, minute) do
+    String.to_integer(hour) * 60 + String.to_integer(minute)
   end
 
   defun shift_milliseconds(t :: v[t], milliseconds :: v[integer]) :: t do


### PR DESCRIPTION
ticket: https://acsmine.tok.access-company.com/redmine/issues/179864

This commit passes `mix credo --strict` for the below seven files:

* `lib/util/cron.ex`
* `lib/util/httpc.ex`
* `local/mix/version_upgrade_test.ex`
* `local/mix/upgrade_compatibility_test.ex`
* `core/metrics/aggregate_strategy/time_distribution.ex`
* `core/mix/generate_release.ex`
* `lib/util/time.ex`

Now all the Credo errors of `Function is too complex` have been resolved combining with https://github.com/access-company/antikythera/pull/51.
