### PR TITLE
[185700] exclude .tool-versions from package contents

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -132,7 +132,7 @@ defmodule Antikythera.Mixfile do
       links:       %{"GitHub" => @github_url},
       files:       [
         "config", "core", "eal", "lib", "local", "priv", "rel",
-        "CHANGELOG.md", "LICENSE", "mix_common.exs", "mix.exs", "README.md", ".tool-versions",
+        "CHANGELOG.md", "LICENSE", "mix_common.exs", "mix.exs", "README.md",
       ],
     ]
   end


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/185700

Exclude `.tool-versions` from package contents because it is no longer required to use antikythera.