### PR TITLE
[185700] Get elixir version from antikythera's `.tool-versions` in CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ references:
       command: |
         echo 'source /usr/local/asdf/asdf.sh' >> $BASH_ENV
         source $BASH_ENV
-        elixir_version="$(curl https://raw.githubusercontent.com/access-company/antikythera_instance_example/master/.tool-versions | grep elixir)"
+        elixir_version="$(grep elixir /usr/local/asdf/tool-versions-copy)"
         asdf global ${elixir_version}
   add_github_hostkey: &add_github_hostkey
     run:
@@ -76,6 +76,13 @@ jobs:
     steps:
       - *install_prerequisites
       - *restore_asdf_directory
+      # To use antikythera's `.tool-versions` file, take the repository here.
+      # Note that we won't save the repository because no change occurs during this job.
+      - restore_cache:
+          keys:
+            - antikythera-repo-{{ .Branch }}-{{ .Revision }}
+            - antikythera-repo-{{ .Branch }}-
+      - checkout
       - run:
           name: Make sure asdf, elixir and local hex/rebar installed
           command: |
@@ -83,11 +90,12 @@ jobs:
             echo 'source /usr/local/asdf/asdf.sh' >> $BASH_ENV
             source $BASH_ENV
             asdf plugin-add elixir || asdf plugin-update elixir
-            elixir_version="$(curl https://raw.githubusercontent.com/access-company/antikythera_instance_example/master/.tool-versions | grep elixir)"
+            elixir_version="$(grep elixir .tool-versions)"
             asdf install ${elixir_version}
             asdf global ${elixir_version}
             mix local.hex --force
             mix local.rebar --force
+            cp -rf .tool-versions /usr/local/asdf/tool-versions-copy
       - save_cache:
           key: asdf_directory-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ references:
       command: |
         echo 'source /usr/local/asdf/asdf.sh' >> $BASH_ENV
         source $BASH_ENV
-        asdf global elixir 1.7.4
+        elixir_version="$(curl https://raw.githubusercontent.com/access-company/antikythera_instance_example/master/.tool-versions | grep elixir)"
+        asdf global ${elixir_version}
   add_github_hostkey: &add_github_hostkey
     run:
       name: Add GitHub's server host key to known_hosts
@@ -82,8 +83,9 @@ jobs:
             echo 'source /usr/local/asdf/asdf.sh' >> $BASH_ENV
             source $BASH_ENV
             asdf plugin-add elixir || asdf plugin-update elixir
-            asdf install elixir 1.7.4
-            asdf global elixir 1.7.4
+            elixir_version="$(curl https://raw.githubusercontent.com/access-company/antikythera_instance_example/master/.tool-versions | grep elixir)"
+            asdf install ${elixir_version}
+            asdf global ${elixir_version}
             mix local.hex --force
             mix local.rebar --force
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             asdf global ${elixir_version}
             mix local.hex --force
             mix local.rebar --force
-            cp -rf .tool-versions /usr/local/asdf/tool-versions-copy
+            cp -f .tool-versions /usr/local/asdf/tool-versions-copy
       - save_cache:
           key: asdf_directory-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -164,6 +164,7 @@ jobs:
           # though artifacts compiled for MIX_ENV=test will be used in upgrade_compatibility_test.
           command: |
             sed -E -i -e "s/(^antikythera_dep .+ ref: )\".+\"/\1\"${CIRCLE_SHA1}\"/" mix.exs
+            cp -f /usr/local/asdf/tool-versions-copy .tool-versions
             mix deps.get || mix deps.get
             mix deps.get
             git --no-pager diff


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/185700

Get elixir version from [this file](https://github.com/access-company/antikythera_instance_example/blob/master/.tool-versions) rather than update manually.