### PR TITLE
[185700] 185700 update least elixir version: `~> 1.6` -> `~> 1.8`

### DIFF
--- a/core/mix/propagate_file_modifications.ex
+++ b/core/mix/propagate_file_modifications.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Compile.PropagateFileModifications do
     recompilation/reload in iex session because `priv/static/**` is not monitored by `:exsync` (in current configuration).
   """
 
-  use Mix.Task # change this to `Mix.Task.Compiler` when upgrading to Elixir v1.6.0
+  use Mix.Task.Compiler
 
   def run(_) do
     mix_common_path = Path.join([__DIR__, "..", "..", "mix_common.exs"])

--- a/lib/mix/gear_static_analysis.ex
+++ b/lib/mix/gear_static_analysis.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Compile.GearStaticAnalysis do
   This task is integrated into `mix compile` command so that these issues are detected each time gear's source code is compiled.
   """
 
-  use Mix.Task # change this to `Mix.Task.Compiler` when upgrading to Elixir v1.6.0
+  use Mix.Task.Compiler
   alias Antikythera.MacroUtil
 
   def run(_) do

--- a/mix_common.exs
+++ b/mix_common.exs
@@ -11,7 +11,7 @@
 defmodule Antikythera.MixCommon do
   def common_project_settings() do
     [
-      elixir:            "~> 1.6",
+      elixir:            "~> 1.8",
       elixirc_options:   [warnings_as_errors: true],
       build_path:        build_path(),
       build_embedded:    Mix.env() == :prod,


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/185700

Antikythera now requires at least version 1.8 of Elixir because [changes in `AntikytheraCore.TemplateEngine`](https://github.com/access-company/antikythera/pull/79/commits/6b0b81e09575fff99dcfa9a295d252200ea23a53) are not backward compatible.