### PR TITLE
[187391] `Map.take/2` should take list (preperation for Elixir 1.9)

### DIFF
--- a/lib/util/map_util.ex
+++ b/lib/util/map_util.ex
@@ -25,7 +25,11 @@ defmodule Antikythera.MapUtil do
       end)
       |> Enum.reject(&is_nil/1)
       |> Map.new()
-    {Map.take(m1, keys_only_in_m1), diffs_with_common_keys, Map.take(m2, keys_only_in_m2)}
+    {
+      Map.take(m1, MapSet.to_list(keys_only_in_m1)),
+      diffs_with_common_keys,
+      Map.take(m2, MapSet.to_list(keys_only_in_m2)),
+    }
   end
 
   @doc """


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/187391

`Map.take/2`'s second argument now should be a list.
https://github.com/elixir-lang/elixir/blob/v1.9/CHANGELOG.md#elixir-3

This PR works on both Elixir 1.8 and 1.9.