### PR TITLE
[187400] use `CIRCLE_WORKFLOW_ID` in cache name of other repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,11 @@ references:
   restore_updated_antikythera_instance_example_directory: &restore_updated_antikythera_instance_example_directory
     restore_cache:
       keys:
-        - antikythera_instance_example-updated_repo-{{ .Branch }}-{{ .Revision }}
+        - antikythera_instance_example-updated_repo-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   restore_testgear_directory: &restore_testgear_directory
     restore_cache:
       keys:
-        - testgear-repo-{{ .Branch }}-{{ .Revision }}
+        - testgear-repo-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
   edit_etc_hosts: &edit_etc_hosts
     run:
       name: Add testgear.localhost and <hostname>.local to /etc/hosts
@@ -67,7 +67,7 @@ references:
   restore_updated_testgear_directory: &restore_updated_testgear_directory
     restore_cache:
       keys:
-        - testgear-updated_repo-{{ .Branch }}-{{ .Revision }}
+        - testgear-updated_repo-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
 
 jobs:
   prepare_elixir:
@@ -130,7 +130,6 @@ jobs:
       - *enable_asdf_and_elixir
       - restore_cache:
           keys:
-            - antikythera_instance_example-repo-{{ .Branch }}-{{ .Revision }}
             - antikythera_instance_example-repo-{{ .Branch }}-
             - antikythera_instance_example-repo-
       - *add_github_hostkey
@@ -148,7 +147,7 @@ jobs:
             MIX_ENV=test mix compile
             MIX_ENV=prod ANTIKYTHERA_COMPILE_ENV=local mix compile
       - save_cache:
-          key: antikythera_instance_example-repo-{{ .Branch }}-{{ .Revision }}
+          key: antikythera_instance_example-repo-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
           paths:
             - .
             - ~/.cache
@@ -173,7 +172,7 @@ jobs:
             MIX_ENV=test mix compile
             MIX_ENV=prod ANTIKYTHERA_COMPILE_ENV=local mix compile
       - save_cache:
-          key: antikythera_instance_example-updated_repo-{{ .Branch }}-{{ .Revision }}
+          key: antikythera_instance_example-updated_repo-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
           paths:
             - .
             - ~/.cache
@@ -186,7 +185,6 @@ jobs:
       - *enable_asdf_and_elixir
       - restore_cache:
           keys:
-            - testgear-repo-{{ .Branch }}-{{ .Revision }}
             - testgear-repo-{{ .Branch }}-
             - testgear-repo-
       - *add_github_hostkey
@@ -216,7 +214,7 @@ jobs:
             MIX_ENV=test mix compile
             MIX_ENV=prod ANTIKYTHERA_COMPILE_ENV=local mix compile
       - save_cache:
-          key: testgear-repo-{{ .Branch }}-{{ .Revision }}
+          key: testgear-repo-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
           paths:
             - .
             - ~/.cache
@@ -269,7 +267,7 @@ jobs:
             MIX_ENV=dev mix compile
             MIX_ENV=test mix compile
       - save_cache:
-          key: testgear-updated_repo-{{ .Branch }}-{{ .Revision }}
+          key: testgear-updated_repo-{{ .Branch }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
           paths:
             - .
             - ~/.cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,6 @@ jobs:
             if [ -n "$(git --no-pager diff)" ]; then
               git --no-pager diff
               git -c user.name='AntikytheraDeploy' -c user.email='antikythera-gr@access-company.com' commit -a -m '[CI] Update antikythera'
-            else
-              echo "skip git commit"
             fi
             MIX_ENV=dev mix compile
             MIX_ENV=test mix compile
@@ -255,8 +253,6 @@ jobs:
           if [ -n "$(git --no-pager diff HEAD origin/master)" ]; then
             git --no-pager show
             git push git@github.com:access-company/antikythera_instance_example.git HEAD:master
-          else
-            echo "skip git push"
           fi
   update_testgear:
     <<: *container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,12 +252,12 @@ jobs:
       - *restore_updated_antikythera_instance_example_directory
       - *add_github_hostkey
       - run: |
-        if [ -n "$(git --no-pager diff HEAD origin/master)" ]; then
-          git --no-pager show
-          git push git@github.com:access-company/antikythera_instance_example.git HEAD:master
-        else
-          echo "skip git push"
-        fi
+          if [ -n "$(git --no-pager diff HEAD origin/master)" ]; then
+            git --no-pager show
+            git push git@github.com:access-company/antikythera_instance_example.git HEAD:master
+          else
+            echo "skip git push"
+          fi
   update_testgear:
     <<: *container_config
     working_directory: /tmp/testgear

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             cp -f /usr/local/asdf/tool-versions-copy .tool-versions
             mix deps.get || mix deps.get
             mix deps.get
-            if [ -n "$(git --no-pager diff)" ]; then
+            if ! git diff --quiet; then
               git --no-pager diff
               git -c user.name='AntikytheraDeploy' -c user.email='antikythera-gr@access-company.com' commit -a -m '[CI] Update antikythera'
             fi
@@ -250,7 +250,7 @@ jobs:
       - *restore_updated_antikythera_instance_example_directory
       - *add_github_hostkey
       - run: |
-          if [ -n "$(git --no-pager diff HEAD origin/master)" ]; then
+          if ! git diff --quiet HEAD origin/master; then
             git --no-pager show
             git push git@github.com:access-company/antikythera_instance_example.git HEAD:master
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,8 +166,12 @@ jobs:
             cp -f /usr/local/asdf/tool-versions-copy .tool-versions
             mix deps.get || mix deps.get
             mix deps.get
-            git --no-pager diff
-            git -c user.name='AntikytheraDeploy' -c user.email='antikythera-gr@access-company.com' commit -a -m '[CI] Update antikythera'
+            if [ -n "$(git --no-pager diff)" ]; then
+              git --no-pager diff
+              git -c user.name='AntikytheraDeploy' -c user.email='antikythera-gr@access-company.com' commit -a -m '[CI] Update antikythera'
+            else
+              echo "skip git commit"
+            fi
             MIX_ENV=dev mix compile
             MIX_ENV=test mix compile
             MIX_ENV=prod ANTIKYTHERA_COMPILE_ENV=local mix compile
@@ -247,8 +251,13 @@ jobs:
     steps:
       - *restore_updated_antikythera_instance_example_directory
       - *add_github_hostkey
-      - run: git --no-pager show
-      - run: git push git@github.com:access-company/antikythera_instance_example.git HEAD:master
+      - run: |
+        if [ -n "$(git --no-pager diff HEAD origin/master)" ]; then
+          git --no-pager show
+          git push git@github.com:access-company/antikythera_instance_example.git HEAD:master
+        else
+          echo "skip git push"
+        fi
   update_testgear:
     <<: *container_config
     working_directory: /tmp/testgear


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/187400

To reflect changes in antikythera_instance_example and testgear repositories without updating antikythera itself, I use an ID of CircleCI workflow in cache names of their repositories.