### PR TITLE
[187391] fix return value of `Mix.Task.Compiler.run/1`

### DIFF
--- a/core/mix/propagate_file_modifications.ex
+++ b/core/mix/propagate_file_modifications.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Compile.PropagateFileModifications do
     touch_if_older_than_any("mix.exs", [mix_common_path])
     touch_if_older_than_any_in_dir(Path.join("web", "template.ex"), Path.join("web", "template"))
     touch_if_older_than_any_in_dir(Path.join("web", "asset.ex"), Path.join("priv", "static"))
-    :ok
+    {:ok, []}
   end
 
   defp touch_if_older_than_any(target, dependencies) do

--- a/lib/mix/gear_static_analysis.ex
+++ b/lib/mix/gear_static_analysis.ex
@@ -238,8 +238,8 @@ defmodule Mix.Tasks.Compile.GearStaticAnalysis do
     n_errors   = length(errors)
     cond do
       n_errors   > 0 -> Mix.raise("#{prefix} Found #{n_errors} errors and #{n_warnings} warnings. Please fix them and try again.")
-      n_warnings > 0 -> IO.puts("#{prefix} Found #{n_warnings} warnings.")
-      true           -> :ok
+      n_warnings > 0 -> {IO.puts("#{prefix} Found #{n_warnings} warnings."), []}
+      true           -> {:ok, []}
     end
   end
 end


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/187391

From Elixir 1.8, `Mix.Task.Compiler.run/1` should return a tuple like the below.

```elixir
{:ok | :noop | :error, [Mix.Task.Compiler.Diagnostic.t()]}
```