### PR TITLE
[187391] Elixir 1.8.2 -> 1.9.1 and fix remote_console

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 20.3.8.9
-elixir 1.8.2
+elixir 1.9.1

--- a/rel/boot_script.patch
+++ b/rel/boot_script.patch
@@ -15,7 +15,7 @@
 >         -boot start_clean -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
 >         -kernel net_ticktime "$TICKTIME" \
 >         -user Elixir.IEx.CLI "$NAME_TYPE" "$id" -setcookie "$COOKIE" \
->         -extra --no-halt +iex -"$NAME_TYPE" "$id" --cookie "$COOKIE" --remsh "$NAME"
+>         -extra --no-halt +iex --remsh "$NAME"
 547c551,553
 <             -pa ${__code_paths}
 ---


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/187391

- remove extra options for `erl`
- update Elixir 1.8.2 -> 1.9.1