### PR TITLE
Define `FastJsonEncoder.encode!/1`

### DIFF
--- a/lib/util/fast_jason_encoder.ex
+++ b/lib/util/fast_jason_encoder.ex
@@ -23,6 +23,7 @@ defmodule Antikythera.FastJasonEncoder do
   defun encode(value :: any) :: R.t(String.t, Jason.EncodeError.t | Exception.t) do
     Jason.encode(%Wrapper{item: value})
   end
+  R.define_bang_version_of(encode: 1)
 
   defun encode(value :: any, opts :: Jason.Encode.opts) :: iodata do
     ([]                 , _   )                       -> "[]"

--- a/lib/web/conn.ex
+++ b/lib/web/conn.ex
@@ -197,7 +197,7 @@ defmodule Antikythera.Conn do
   Returns a JSON response.
   """
   defun json(%__MODULE__{resp_headers: resp_headers} = conn, status :: v[Http.Status.t], body :: v[%{(atom | String.t) => any} | [any]]) :: t do
-    {:ok, json} = FastJasonEncoder.encode(body)
+    json = FastJasonEncoder.encode!(body)
     %__MODULE__{conn |
       status:       Http.Status.code(status),
       resp_headers: Map.put(resp_headers, "content-type", "application/json"),

--- a/lib/web/conn.ex
+++ b/lib/web/conn.ex
@@ -197,11 +197,10 @@ defmodule Antikythera.Conn do
   Returns a JSON response.
   """
   defun json(%__MODULE__{resp_headers: resp_headers} = conn, status :: v[Http.Status.t], body :: v[%{(atom | String.t) => any} | [any]]) :: t do
-    json = FastJasonEncoder.encode!(body)
     %__MODULE__{conn |
       status:       Http.Status.code(status),
       resp_headers: Map.put(resp_headers, "content-type", "application/json"),
-      resp_body:    json,
+      resp_body:    FastJasonEncoder.encode!(body),
     }
   end
 


### PR DESCRIPTION
In my project, `FastJsonEncoder.encode!/1` will be useful.

I didn't write additional tests for `encode!/1` because `encode/1` is tested.
