### PR TITLE
[216773] Throw MatchError if about half of gears are not installed

### DIFF
--- a/core/sup_tree_core/version_synchronizer.ex
+++ b/core/sup_tree_core/version_synchronizer.ex
@@ -59,7 +59,7 @@ defmodule AntikytheraCore.VersionSynchronizer do
   end
 
   defp install_gears() do
-    Version.Gear.install_gears_at_startup(History.all_deployable_gear_names())
+    :ok = Version.Gear.install_gears_at_startup(History.all_deployable_gear_names())
     StartupManager.all_gears_installed()
   end
 

--- a/core/version/gear.ex
+++ b/core/version/gear.ex
@@ -157,7 +157,7 @@ defmodule AntikytheraCore.Version.Gear do
     needs_check = Antikythera.Env.runtime_env() != :local
 
     is_enough_gears_installed =
-      num_installable != 0 && num_installed / num_installable > @installed_gear_ratio_threshold
+      num_installable != 0 and num_installed / num_installable > @installed_gear_ratio_threshold
 
     if !needs_check || is_enough_gears_installed do
       :ok

--- a/core/version/gear.ex
+++ b/core/version/gear.ex
@@ -130,21 +130,28 @@ defmodule AntikytheraCore.Version.Gear do
         {g, __MODULE__.gear_dependencies_from_app_file(g, gear_names)}
       end)
 
-    pairs_not_installed =
-      __MODULE__.install_gears_whose_deps_met(gear_and_deps_pairs, MapSet.new(), fn gear_name ->
-        try do
-          install_or_upgrade_to_next_version(gear_name)
-        rescue
-          e -> L.error("Failed to install #{gear_name}: #{Exception.message(e)}")
+    {pairs_not_installed, num_failed_install} =
+      __MODULE__.install_gears_whose_deps_met(
+        gear_and_deps_pairs,
+        MapSet.new(),
+        0,
+        fn gear_name ->
+          try do
+            install_or_upgrade_to_next_version(gear_name)
+          rescue
+            e ->
+              L.error("Failed to install #{gear_name}: #{Exception.message(e)}")
+              :error
+          end
         end
-      end)
+      )
 
     Enum.each(pairs_not_installed, fn {gear_name, deps} ->
       L.error("#{gear_name} is not installed due to unmatched dependencies: #{inspect(deps)}")
     end)
 
     num_installable = length(gear_names)
-    num_installed = num_installable - length(pairs_not_installed)
+    num_installed = num_installable - length(pairs_not_installed) - num_failed_install
     # version_upgrade_test starts Antikythera without gears.
     # Then, we can't check number of installed gears.
     needs_check = Antikythera.Env.runtime_env() != :local
@@ -163,24 +170,26 @@ defmodule AntikytheraCore.Version.Gear do
   defun install_gears_whose_deps_met(
           pairs :: v[[gear_and_deps_pair]],
           installed_gears_set :: MapSet.t(),
-          f :: (GearName.t() -> :ok)
-        ) :: [gear_and_deps_pair] do
+          num_failed_install :: v[non_neg_integer],
+          f :: (GearName.t() -> :ok | :error)
+        ) :: {[gear_and_deps_pair], non_neg_integer} do
     if Enum.empty?(pairs) do
-      []
+      {[], num_failed_install}
     else
       {pairs_installable, pairs_not_installable} =
         Enum.split_with(pairs, fn {_, deps} -> MapSet.subset?(deps, installed_gears_set) end)
 
       if Enum.empty?(pairs_installable) do
         # we cannot make progress any more
-        pairs_not_installable
+        {pairs_not_installable, num_failed_install}
       else
         gears_installable = Keyword.keys(pairs_installable)
-        Enum.each(gears_installable, f)
+        gears_installed = Enum.filter(gears_installable, fn gear -> f.(gear) == :ok end)
 
         install_gears_whose_deps_met(
           pairs_not_installable,
-          Enum.into(gears_installable, installed_gears_set),
+          Enum.into(gears_installed, installed_gears_set),
+          num_failed_install + length(gears_installable) - length(gears_installed),
           f
         )
       end

--- a/test/core/version/gear_test.exs
+++ b/test/core/version/gear_test.exs
@@ -57,11 +57,7 @@ defmodule AntikytheraCore.Version.GearTest do
 
       {ret, num_failed_install} =
         V.install_gears_whose_deps_met(pairs, MapSet.new(), 0, fn g ->
-          if g == failed_to_install_gear do
-            :error
-          else
-            :ok
-          end
+          if g == failed_to_install_gear, do: :error, else: :ok
         end)
 
       assert Enum.empty?(ret)
@@ -76,11 +72,7 @@ defmodule AntikytheraCore.Version.GearTest do
 
       {ret, num_failed_install} =
         V.install_gears_whose_deps_met(pairs, MapSet.new(), 0, fn g ->
-          if g == failed_to_install_gear do
-            :error
-          else
-            :ok
-          end
+          if g == failed_to_install_gear, do: :error, else: :ok
         end)
 
       assert set(ret) == set(pairs_to_be_rejected)

--- a/test/core/version/gear_test.exs
+++ b/test/core/version/gear_test.exs
@@ -38,11 +38,9 @@ defmodule AntikytheraCore.Version.GearTest do
     |> Enum.each(fn {pairs, gears_to_be_rejected} ->
       pairs_to_be_rejected = Enum.filter(pairs, fn {g, _} -> g in gears_to_be_rejected end)
 
-      {ret, num_installed} =
-        V.install_gears_whose_deps_met(pairs, MapSet.new(), fn g -> send(self(), g) end)
+      ret = V.install_gears_whose_deps_met(pairs, MapSet.new(), fn g -> send(self(), g) end)
 
       assert set(ret) == set(pairs_to_be_rejected)
-      assert num_installed == length(pairs) - length(gears_to_be_rejected)
       assert set(all_messages_in_mailbox()) == set(Keyword.keys(pairs) -- gears_to_be_rejected)
     end)
   end
@@ -57,8 +55,6 @@ defmodule AntikytheraCore.Version.GearTest do
       gears = [:gear1, :gear2, :gear3]
       pairs_not_installed = []
 
-      num_installed = length(gears) - length(pairs_not_installed)
-
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
         MapSet.new()
@@ -68,7 +64,7 @@ defmodule AntikytheraCore.Version.GearTest do
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
         fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          {pairs_not_installed, num_installed}
+          pairs_not_installed
         end
       )
 
@@ -79,8 +75,6 @@ defmodule AntikytheraCore.Version.GearTest do
       gears = [:gear1, :gear2, :gear3]
       pairs_not_installed = [gear1: set([]), gear2: set([])]
 
-      num_installed = length(gears) - length(pairs_not_installed)
-
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
         MapSet.new()
@@ -90,7 +84,7 @@ defmodule AntikytheraCore.Version.GearTest do
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
         fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          {pairs_not_installed, num_installed}
+          pairs_not_installed
         end
       )
 
@@ -101,8 +95,6 @@ defmodule AntikytheraCore.Version.GearTest do
       gears = [:gear1, :gear2, :gear3, :gear4]
       pairs_not_installed = [gear1: set([]), gear2: set([])]
 
-      num_installed = length(gears) - length(pairs_not_installed)
-
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
         MapSet.new()
@@ -112,7 +104,7 @@ defmodule AntikytheraCore.Version.GearTest do
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
         fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          {pairs_not_installed, num_installed}
+          pairs_not_installed
         end
       )
 
@@ -123,8 +115,6 @@ defmodule AntikytheraCore.Version.GearTest do
       gears = []
       pairs_not_installed = []
 
-      num_installed = length(gears) - length(pairs_not_installed)
-
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
         MapSet.new()
@@ -134,7 +124,7 @@ defmodule AntikytheraCore.Version.GearTest do
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
         fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          {pairs_not_installed, num_installed}
+          pairs_not_installed
         end
       )
 

--- a/test/core/version/gear_test.exs
+++ b/test/core/version/gear_test.exs
@@ -15,6 +15,12 @@ defmodule AntikytheraCore.Version.GearTest do
     MapSet.new(l)
   end
 
+  setup do
+    on_exit(fn ->
+      :meck.unload()
+    end)
+  end
+
   test "install_gears_whose_deps_met/3 should appropriately reorder gear installations according to their gear dependencies" do
     %{
       [] => [],
@@ -31,8 +37,12 @@ defmodule AntikytheraCore.Version.GearTest do
     }
     |> Enum.each(fn {pairs, gears_to_be_rejected} ->
       pairs_to_be_rejected = Enum.filter(pairs, fn {g, _} -> g in gears_to_be_rejected end)
-      ret = V.install_gears_whose_deps_met(pairs, MapSet.new(), fn g -> send(self(), g) end)
+
+      {ret, num_installed} =
+        V.install_gears_whose_deps_met(pairs, MapSet.new(), fn g -> send(self(), g) end)
+
       assert set(ret) == set(pairs_to_be_rejected)
+      assert num_installed == length(pairs) - length(gears_to_be_rejected)
       assert set(all_messages_in_mailbox()) == set(Keyword.keys(pairs) -- gears_to_be_rejected)
     end)
   end
@@ -40,5 +50,95 @@ defmodule AntikytheraCore.Version.GearTest do
   test "auto_generated_module?" do
     refute V.auto_generated_module?(Antikythera.Time)
     assert V.auto_generated_module?(Croma.TypeGen.Nilable.Antikythera.Time)
+  end
+
+  describe "install_gears_at_startup/1" do
+    test "should return :ok if most gears are installed" do
+      gears = [:gear1, :gear2, :gear3]
+      pairs_not_installed = []
+
+      num_installed = length(gears) - length(pairs_not_installed)
+
+      :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
+                                                                                      _known_gear_names ->
+        MapSet.new()
+      end)
+
+      :meck.expect(
+        AntikytheraCore.Version.Gear,
+        :install_gears_whose_deps_met,
+        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
+          {pairs_not_installed, num_installed}
+        end
+      )
+
+      assert V.do_install_gears_at_startup(gears) == :ok
+    end
+
+    test "should return :error if most gears are not installed" do
+      gears = [:gear1, :gear2, :gear3]
+      pairs_not_installed = [gear1: set([]), gear2: set([])]
+
+      num_installed = length(gears) - length(pairs_not_installed)
+
+      :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
+                                                                                      _known_gear_names ->
+        MapSet.new()
+      end)
+
+      :meck.expect(
+        AntikytheraCore.Version.Gear,
+        :install_gears_whose_deps_met,
+        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
+          {pairs_not_installed, num_installed}
+        end
+      )
+
+      assert V.do_install_gears_at_startup(gears) == :error
+    end
+
+    test "should return :error if half of gears are not installed" do
+      gears = [:gear1, :gear2, :gear3, :gear4]
+      pairs_not_installed = [gear1: set([]), gear2: set([])]
+
+      num_installed = length(gears) - length(pairs_not_installed)
+
+      :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
+                                                                                      _known_gear_names ->
+        MapSet.new()
+      end)
+
+      :meck.expect(
+        AntikytheraCore.Version.Gear,
+        :install_gears_whose_deps_met,
+        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
+          {pairs_not_installed, num_installed}
+        end
+      )
+
+      assert V.do_install_gears_at_startup(gears) == :error
+    end
+
+    test "should return :error if 0 gear is installable" do
+      gears = []
+      pairs_not_installed = []
+
+      num_installed = length(gears) - length(pairs_not_installed)
+
+      :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
+                                                                                      _known_gear_names ->
+        MapSet.new()
+      end)
+
+      :meck.expect(
+        AntikytheraCore.Version.Gear,
+        :install_gears_whose_deps_met,
+        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
+          {pairs_not_installed, num_installed}
+        end
+      )
+
+      assert V.do_install_gears_at_startup(gears) == :error
+    end
   end
 end

--- a/test/core/version/gear_test.exs
+++ b/test/core/version/gear_test.exs
@@ -21,28 +21,71 @@ defmodule AntikytheraCore.Version.GearTest do
     end)
   end
 
-  test "install_gears_whose_deps_met/3 should appropriately reorder gear installations according to their gear dependencies" do
-    %{
-      [] => [],
-      [gear_a: set([]), gear_b: set([])] => [],
-      [gear_a: set([:gear_b]), gear_b: set([])] => [],
-      [gear_a: set([:gear_b, :gear_c]), gear_b: set([:gear_c]), gear_c: set([])] => [],
-      [gear_a: set([:gear_b])] => [:gear_a],
-      [gear_a: set([:gear_c]), gear_b: set([])] => [:gear_a],
-      [gear_a: set([:gear_b]), gear_b: set([:gear_c]), gear_c: set([:gear_a])] => [
-        :gear_a,
-        :gear_b,
-        :gear_c
-      ]
-    }
-    |> Enum.each(fn {pairs, gears_to_be_rejected} ->
+  describe "install_gears_whose_deps_met/3" do
+    test "should appropriately reorder gear installations according to their gear dependencies" do
+      %{
+        [] => [],
+        [gear_a: set([]), gear_b: set([])] => [],
+        [gear_a: set([:gear_b]), gear_b: set([])] => [],
+        [gear_a: set([:gear_b, :gear_c]), gear_b: set([:gear_c]), gear_c: set([])] => [],
+        [gear_a: set([:gear_b])] => [:gear_a],
+        [gear_a: set([:gear_c]), gear_b: set([])] => [:gear_a],
+        [gear_a: set([:gear_b]), gear_b: set([:gear_c]), gear_c: set([:gear_a])] => [
+          :gear_a,
+          :gear_b,
+          :gear_c
+        ]
+      }
+      |> Enum.each(fn {pairs, gears_to_be_rejected} ->
+        pairs_to_be_rejected = Enum.filter(pairs, fn {g, _} -> g in gears_to_be_rejected end)
+
+        {ret, num_failed_install} =
+          V.install_gears_whose_deps_met(pairs, MapSet.new(), 0, fn g ->
+            send(self(), g)
+            :ok
+          end)
+
+        assert set(ret) == set(pairs_to_be_rejected)
+        assert num_failed_install == 0
+        assert set(all_messages_in_mailbox()) == set(Keyword.keys(pairs) -- gears_to_be_rejected)
+      end)
+    end
+
+    test "should return number of failed to install gears" do
+      pairs = [gear_a: set([]), gear_b: set([]), gear_c: set([])]
+      failed_to_install_gear = :gear_b
+
+      {ret, num_failed_install} =
+        V.install_gears_whose_deps_met(pairs, MapSet.new(), 0, fn g ->
+          if g == failed_to_install_gear do
+            :error
+          else
+            :ok
+          end
+        end)
+
+      assert Enum.empty?(ret)
+      assert num_failed_install == 1
+    end
+
+    test "should reject if it failed to install depending gears" do
+      pairs = [gear_a: set([:gear_b]), gear_b: set([]), gear_c: set([])]
+      failed_to_install_gear = :gear_b
+      gears_to_be_rejected = [:gear_a]
       pairs_to_be_rejected = Enum.filter(pairs, fn {g, _} -> g in gears_to_be_rejected end)
 
-      ret = V.install_gears_whose_deps_met(pairs, MapSet.new(), fn g -> send(self(), g) end)
+      {ret, num_failed_install} =
+        V.install_gears_whose_deps_met(pairs, MapSet.new(), 0, fn g ->
+          if g == failed_to_install_gear do
+            :error
+          else
+            :ok
+          end
+        end)
 
       assert set(ret) == set(pairs_to_be_rejected)
-      assert set(all_messages_in_mailbox()) == set(Keyword.keys(pairs) -- gears_to_be_rejected)
-    end)
+      assert num_failed_install == 1
+    end
   end
 
   test "auto_generated_module?" do
@@ -54,6 +97,7 @@ defmodule AntikytheraCore.Version.GearTest do
     test "should return :ok if most gears are installed" do
       gears = [:gear1, :gear2, :gear3]
       pairs_not_installed = []
+      num_failed_to_install = 0
 
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
@@ -63,8 +107,8 @@ defmodule AntikytheraCore.Version.GearTest do
       :meck.expect(
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
-        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          pairs_not_installed
+        fn _gear_and_deps_pairs, _installed_gears_set, _f, _num_failed_install ->
+          {pairs_not_installed, num_failed_to_install}
         end
       )
 
@@ -74,6 +118,7 @@ defmodule AntikytheraCore.Version.GearTest do
     test "should return :error if most gears are not installed" do
       gears = [:gear1, :gear2, :gear3]
       pairs_not_installed = [gear1: set([]), gear2: set([])]
+      num_failed_to_install = 0
 
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
@@ -83,8 +128,29 @@ defmodule AntikytheraCore.Version.GearTest do
       :meck.expect(
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
-        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          pairs_not_installed
+        fn _gear_and_deps_pairs, _installed_gears_set, _f, _num_failed_install ->
+          {pairs_not_installed, num_failed_to_install}
+        end
+      )
+
+      assert V.do_install_gears_at_startup(gears) == :error
+    end
+
+    test "should return :error if most gears are failed to install" do
+      gears = [:gear1, :gear2, :gear3]
+      pairs_not_installed = []
+      num_failed_to_install = 2
+
+      :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
+                                                                                      _known_gear_names ->
+        MapSet.new()
+      end)
+
+      :meck.expect(
+        AntikytheraCore.Version.Gear,
+        :install_gears_whose_deps_met,
+        fn _gear_and_deps_pairs, _installed_gears_set, _f, _num_failed_install ->
+          {pairs_not_installed, num_failed_to_install}
         end
       )
 
@@ -94,6 +160,7 @@ defmodule AntikytheraCore.Version.GearTest do
     test "should return :error if half of gears are not installed" do
       gears = [:gear1, :gear2, :gear3, :gear4]
       pairs_not_installed = [gear1: set([]), gear2: set([])]
+      num_failed_to_install = 0
 
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
@@ -103,8 +170,8 @@ defmodule AntikytheraCore.Version.GearTest do
       :meck.expect(
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
-        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          pairs_not_installed
+        fn _gear_and_deps_pairs, _installed_gears_set, _f, _num_failed_install ->
+          {pairs_not_installed, num_failed_to_install}
         end
       )
 
@@ -114,6 +181,7 @@ defmodule AntikytheraCore.Version.GearTest do
     test "should return :error if 0 gear is installable" do
       gears = []
       pairs_not_installed = []
+      num_failed_to_install = 0
 
       :meck.expect(AntikytheraCore.Version.Gear, :gear_dependencies_from_app_file, fn _gear_name,
                                                                                       _known_gear_names ->
@@ -123,8 +191,8 @@ defmodule AntikytheraCore.Version.GearTest do
       :meck.expect(
         AntikytheraCore.Version.Gear,
         :install_gears_whose_deps_met,
-        fn _gear_and_deps_pairs, _installed_gears_set, _f ->
-          pairs_not_installed
+        fn _gear_and_deps_pairs, _installed_gears_set, _f, _num_failed_install ->
+          {pairs_not_installed, num_failed_to_install}
         end
       )
 

--- a/test/core/version/gear_test.exs
+++ b/test/core/version/gear_test.exs
@@ -21,7 +21,7 @@ defmodule AntikytheraCore.Version.GearTest do
     end)
   end
 
-  describe "install_gears_whose_deps_met/3" do
+  describe "install_gears_whose_deps_met/4" do
     test "should appropriately reorder gear installations according to their gear dependencies" do
       %{
         [] => [],


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/216773

Antikythera returns healthy to healthy API even if there is no running gear.  Generally speaking, this in not healthy.

`Version.Gear.install_gears_at_startup/1` returns :error if equal or less than half of gears are installed. Then, `AntikytheraCore.VersionSynchronizer.install_gears/0` try to match it with `:ok`. This won't call `StartupManager.all_gears_installed/0` which makes Antikythera healthy state.