### PR TITLE
[222347] Change parameters to handle larger gear log size

### DIFF
--- a/core/gear_log/file_handle.ex
+++ b/core/gear_log/file_handle.ex
@@ -9,7 +9,7 @@ defmodule AntikytheraCore.GearLog.FileHandle do
   defmodule SizeCheck do
     @interval if Antikythera.Env.compiling_for_release?() ||
                    Antikythera.Env.compiling_for_mix_task?(),
-                 do: 60_000,
+                 do: 30_000,
                  else: 100
     # 100MB
     @max_size if Mix.env() == :test, do: 4_096, else: 104_857_600

--- a/lib/util/httpc.ex
+++ b/lib/util/httpc.ex
@@ -5,7 +5,7 @@ use Croma
 defmodule Antikythera.Httpc do
   @default_max_body 10 * 1024 * 1024
   # To fetch log files created by `GearLog.Writer` this must be larger than the max log file size.
-  @maximum_max_body 120 * 1024 * 1024
+  @maximum_max_body 150 * 1024 * 1024
   defun default_max_body() :: pos_integer, do: @default_max_body
   defun maximum_max_body() :: pos_integer, do: @maximum_max_body
 


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/222347#note-8

If there are hundreds of thousands of requests per minute to a gear, the size of the log file increase several tens of MB and may exceed the max body size limit.
So,
- I suggest increasing the max body size limit.
- I also suggest shortening the size check interval to reduce the rapid increase in log file size.
