### PR TITLE
Read Set-Cookie header options from Session plug's options

### DIFF
--- a/lib/web/plug/session.ex
+++ b/lib/web/plug/session.ex
@@ -20,10 +20,14 @@ defmodule Antikythera.Plug.Session do
 
   alias Antikythera.Conn
   alias Antikythera.Session
+  alias Antikythera.Http
 
-  defun load(conn :: v[Conn.t()], opts :: Keyword.t(String.t() | atom | map)) :: Conn.t() do
+  @type load_option_t ::
+          {:key, String.t()} | {:store, atom} | {:set_cookie, Http.SetCookie.options_t()}
+
+  defun load(conn :: v[Conn.t()], opts :: v[list(load_option_t)]) :: Conn.t() do
     key             = opts[:key]
-    set_cookie_opts = opts[:set_cookie]
+    set_cookie_opts = Keyword.get(opts, :set_cookie, %{})
     store_name = Keyword.get(opts, :store, :cookie) |> Atom.to_string() |> Macro.camelize()
     store_module = Module.safe_concat("Antikythera.Session", store_name)
     {session_id, data} = store_module.load(Conn.get_req_cookie(conn, key))

--- a/lib/web/plug/session.ex
+++ b/lib/web/plug/session.ex
@@ -21,8 +21,9 @@ defmodule Antikythera.Plug.Session do
   alias Antikythera.Conn
   alias Antikythera.Session
 
-  defun load(conn :: v[Conn.t()], opts :: Keyword.t(String.t() | atom)) :: Conn.t() do
-    key = opts[:key]
+  defun load(conn :: v[Conn.t()], opts :: Keyword.t(String.t() | atom | map)) :: Conn.t() do
+    key             = opts[:key]
+    set_cookie_opts = opts[:set_cookie]
     store_name = Keyword.get(opts, :store, :cookie) |> Atom.to_string() |> Macro.camelize()
     store_module = Module.safe_concat("Antikythera.Session", store_name)
     {session_id, data} = store_module.load(Conn.get_req_cookie(conn, key))
@@ -34,23 +35,23 @@ defmodule Antikythera.Plug.Session do
     }
 
     conn
-    |> Conn.register_before_send(make_before_send(store_module, key))
+    |> Conn.register_before_send(make_before_send(store_module, key, set_cookie_opts))
     |> Conn.assign(:session, session)
   end
 
-  defunp make_before_send(store :: module, key :: String.t()) :: (Conn.t() -> Conn.t()) do
+  defunp make_before_send(store :: module, key :: String.t(), set_cookie_opts :: map) :: (Conn.t() -> Conn.t()) do
     fn %Conn{assigns: %{session: session}} = conn ->
       %Session{state: state, id: id, data: data} = session
 
       case state do
         :update ->
           new_id = store.save(id, data)
-          Conn.put_resp_cookie(conn, key, new_id)
+          Conn.put_resp_cookie(conn, key, new_id, set_cookie_opts)
 
         :renew ->
           store.delete(id)
           new_id = store.save(nil, data)
-          Conn.put_resp_cookie(conn, key, new_id)
+          Conn.put_resp_cookie(conn, key, new_id, set_cookie_opts)
 
         :destroy ->
           store.delete(id)

--- a/lib/web/plug/session.ex
+++ b/lib/web/plug/session.ex
@@ -26,7 +26,7 @@ defmodule Antikythera.Plug.Session do
           {:key, String.t()} | {:store, atom} | {:set_cookie, Http.SetCookie.options_t()}
 
   defun load(conn :: v[Conn.t()], opts :: v[list(load_option_t)]) :: Conn.t() do
-    key             = opts[:key]
+    key = opts[:key]
     set_cookie_opts = Keyword.get(opts, :set_cookie, %{})
     store_name = Keyword.get(opts, :store, :cookie) |> Atom.to_string() |> Macro.camelize()
     store_module = Module.safe_concat("Antikythera.Session", store_name)
@@ -43,7 +43,8 @@ defmodule Antikythera.Plug.Session do
     |> Conn.assign(:session, session)
   end
 
-  defunp make_before_send(store :: module, key :: String.t(), set_cookie_opts :: map) :: (Conn.t() -> Conn.t()) do
+  defunp make_before_send(store :: module, key :: String.t(), set_cookie_opts :: map) ::
+           (Conn.t() -> Conn.t()) do
     fn %Conn{assigns: %{session: session}} = conn ->
       %Session{state: state, id: id, data: data} = session
 


### PR DESCRIPTION
# Rationale

This is related to #186 (specifically "Add an interface to `Antikythera.Plug.Session.load/2`"), but it stems from a different purpose, where we needed to explicitly set the expiration period of the session cookie.
This enables the gear to specify the behavior of the session cookie via the keyword list passed to the plug.

# Part that I may need help on

- Type signature of `load/2` 's `opts` variable. The keyword list should accept a map (which is passed to `make_before_send/3`), but this specification might be too broad
    - Note: I have ran `mix dialyzer` and got no warnings
- Are there any test codes relating to this specific code?
- What to do if store is not a cookie?