### PR TITLE
[157956] Remove migration code used when upgrading to Erlang 21+

### DIFF
--- a/core/util/erlang_log_translator.ex
+++ b/core/util/erlang_log_translator.ex
@@ -14,25 +14,12 @@ defmodule AntikytheraCore.ErlangLogTranslator do
   - supervisor report on brutal kill of a worker process in PoolSup (when a too-long-running worker is stopped)
   """
 
-  # TODO: remove after upgrading to Erlang/OTP 21+
-  def translate(_min_level, :info, :report, {:progress, _data}) do
-    :skip
-  end
-
   def translate(_min_level, :info, :report, {{_reporter, :progress}, _data}) do
     :skip
   end
 
   def translate(_min_level, :error, :format, {'Received a MNESIA down event' ++ _, _}) do
     :skip
-  end
-
-  # TODO: remove after upgrading to Erlang/OTP 21+
-  def translate(min_level, :error, :report, {:supervisor_report, kw} = message) do
-    case Keyword.get(kw, :supervisor) do
-      {_pid, PoolSup.Callback} -> :skip
-      _otherwise -> Logger.Translator.translate(min_level, :error, :report, message)
-    end
   end
 
   def translate(min_level, :error, :report, {{:supervisor, :child_terminated}, kw} = message) do


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/157956#note-84