### PR TITLE
[239881] Disable protocol consolidation

### DIFF
--- a/mix_common.exs
+++ b/mix_common.exs
@@ -11,13 +11,14 @@
 defmodule Antikythera.MixCommon do
   def common_project_settings() do
     [
-      elixir:            "~> 1.9",
-      elixirc_options:   [warnings_as_errors: true],
-      build_path:        build_path(),
-      build_embedded:    Mix.env() == :prod,
-      test_coverage:     [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.html": :test, "antikythera_local.upgrade_compatibility_test": :test],
-      xref:              [exclude: [EEx, EEx.Engine]], # Suppress undefined application warnings
+      elixir:                "~> 1.9",
+      elixirc_options:       [warnings_as_errors: true],
+      build_path:            build_path(),
+      build_embedded:        Mix.env() == :prod,
+      test_coverage:         [tool: ExCoveralls],
+      preferred_cli_env:     [coveralls: :test, "coveralls.detail": :test, "coveralls.html": :test, "antikythera_local.upgrade_compatibility_test": :test],
+      xref:                  [exclude: [EEx, EEx.Engine]], # Suppress undefined application warnings
+      consolidate_protocols: false, # Avoid inclusion of consolidated protocol information in the core PLT file
     ]
   end
 

--- a/mix_common.exs
+++ b/mix_common.exs
@@ -18,7 +18,10 @@ defmodule Antikythera.MixCommon do
       test_coverage:         [tool: ExCoveralls],
       preferred_cli_env:     [coveralls: :test, "coveralls.detail": :test, "coveralls.html": :test, "antikythera_local.upgrade_compatibility_test": :test],
       xref:                  [exclude: [EEx, EEx.Engine]], # Suppress undefined application warnings
-      consolidate_protocols: false, # Avoid inclusion of consolidated protocol information in the core PLT file
+
+      # Avoid inclusion of consolidated protocol information in the core PLT file also in Elixir 1.11+.
+      # Since the release build have not used protocol consolidation, this setting does not affect performance in release.
+      consolidate_protocols: false,
     ]
   end
 


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/239881#note-78

* * *

## Purpose

* To avoid inclusion of consolidated protocol information in the core PLT file in Elixir 1.11+.

## Reason

* In Elixir 1.11+, dialyxir becomes to make a core PLT file with project-specific consolidated protocol information.
  * Maybe [this commit](/elixir-lang/elixir/commit/4bd3c9936ba4d6d72b662655bfd4ab7c5a283e0a) caused it.
* In other words, the core PLT file is rewritten for each type checking.
  * It fails if the operator (e.g. CI/CD tool) does not have write permission for the file.
* Disabling protocol consolidation resolves this issue.

## Effect

* There seems  to be no performance degradation in release.
  * Release builds of Antikythera have not used protocol consolidation for a long time.
