### PR TITLE
[258506] Use compile_env instead of fetch_env or get_env during compiling

### DIFF
--- a/core/alert/handler/email.ex
+++ b/core/alert/handler/email.ex
@@ -26,7 +26,7 @@ defmodule AntikytheraCore.Alert.Handler.Email do
 
   @behaviour AntikytheraCore.Alert.Handler
 
-  @from Application.fetch_env!(:antikythera, :alert) |> get_in([:email, :from])
+  @from Application.compile_env!(:antikythera, :alert) |> get_in([:email, :from])
   if !Email.valid?(@from) do
     raise "please set a valid email address in application config (as nested keyword list of `[:alert, :email, :from]`)"
   end

--- a/core/executor_pool/registered_name.ex
+++ b/core/executor_pool/registered_name.ex
@@ -93,7 +93,7 @@ defmodule AntikytheraCore.ExecutorPool.RegisteredName do
   # Async job queues are treated a bit differently, as they are cluster-wide.
   # `:async_job_queue_name_prefix` is introduced here so that some existing deployments can preserve the historic name of job queues.
   # New deployments should be OK with the default value.
-  @job_queue_prefix Application.get_env(:antikythera, :async_job_queue_name_prefix, @prefix)
+  @job_queue_prefix Application.compile_env(:antikythera, :async_job_queue_name_prefix, @prefix)
 
   defun async_job_queue(epool_id :: v[EPoolId.t()]) :: atom do
     Module.safe_concat(async_job_queue_parts(epool_id))

--- a/core/handler/cowboy_routing.ex
+++ b/core/handler/cowboy_routing.ex
@@ -96,7 +96,7 @@ defmodule AntikytheraCore.Handler.CowboyRouting do
   #
   # Handling domains
   #
-  @deployments Application.fetch_env!(:antikythera, :deployments)
+  @deployments Application.compile_env!(:antikythera, :deployments)
   @current_compile_env Env.compile_env()
 
   defunp base_domain(env :: v[Env.t()]) :: Domain.t() do

--- a/core/handler/gear_action/gear_action.ex
+++ b/core/handler/gear_action/gear_action.ex
@@ -8,7 +8,7 @@ defmodule AntikytheraCore.Handler.GearAction do
   alias AntikytheraCore.Conn, as: CoreConn
   alias AntikytheraCore.{MetricsUploader, Handler.HelperModules, GearLog.Writer}
 
-  @http_headers_to_log Application.fetch_env!(:antikythera, :http_headers_to_log)
+  @http_headers_to_log Application.compile_env!(:antikythera, :http_headers_to_log)
 
   defun split_path_to_segments(path :: v[String.t()]) :: PathInfo.t() do
     String.split(path, "/")

--- a/core/handler/gear_error.ex
+++ b/core/handler/gear_error.ex
@@ -121,7 +121,7 @@ defmodule AntikytheraCore.Handler.GearError do
     end
   end
 
-  if Application.fetch_env!(:antikythera, :return_detailed_info_on_error?) do
+  if Application.compile_env!(:antikythera, :return_detailed_info_on_error?) do
     defun internal_error_body(conn :: Conn.t(), reason :: reason, stacktrace :: stacktrace) ::
             String.t() do
       [

--- a/core/util/path.ex
+++ b/core/util/path.ex
@@ -12,7 +12,7 @@ defmodule AntikytheraCore.Path do
   #
   if Env.compiling_for_cloud?() do
     # Use compile-time application config
-    @antikythera_root_dir Application.fetch_env!(:antikythera, :antikythera_root_dir)
+    @antikythera_root_dir Application.compile_env!(:antikythera, :antikythera_root_dir)
     defun antikythera_root_dir() :: Path.t(), do: @antikythera_root_dir
     defun compiled_core_dir() :: Path.t(), do: Path.join(antikythera_root_dir(), "releases")
   else

--- a/core/version/gear.ex
+++ b/core/version/gear.ex
@@ -10,7 +10,7 @@ defmodule AntikytheraCore.Version.Gear do
   require AntikytheraCore.Logger, as: L
 
   @installed_gear_ratio_threshold 0.5
-  @notify_threshold Application.fetch_env!(
+  @notify_threshold Application.compile_env!(
                       :antikythera,
                       :gear_install_notify_threshold_in_seconds
                     )

--- a/lib/test/config.ex
+++ b/lib/test/config.ex
@@ -19,7 +19,7 @@ defmodule Antikythera.Test.Config do
   # TODO: remove when upgrading to Elixir v1.10+ where this timeout is infinity
   @long_module_load_timeout 600_000
 
-  deployment_envs = Application.fetch_env!(:antikythera, :deployments) |> Keyword.keys()
+  deployment_envs = Application.compile_env!(:antikythera, :deployments) |> Keyword.keys()
 
   def init() do
     System.at_exit(fn _ -> stop_gear_supervisors() end)

--- a/lib/util/env.ex
+++ b/lib/util/env.ex
@@ -42,7 +42,7 @@ defmodule Antikythera.Env do
   You can use these values to distinguish the current context from your code.
   """
 
-  deployment_envs = Application.fetch_env!(:antikythera, :deployments) |> Keyword.keys()
+  deployment_envs = Application.compile_env!(:antikythera, :deployments) |> Keyword.keys()
   use Croma.SubtypeOfAtom, values: deployment_envs ++ [:local, :undefined]
   alias Antikythera.{GearName, GearNameStr, Url}
   alias AntikytheraCore.Handler.CowboyRouting, as: Routing
@@ -96,7 +96,7 @@ defmodule Antikythera.Env do
 
   defun compiling_for_cloud?() :: boolean, do: !compiling_for_mix_task?() && @compiling_for_cloud?
 
-  @antikythera_instance_name Application.fetch_env!(:antikythera, :antikythera_instance_name)
+  @antikythera_instance_name Application.compile_env!(:antikythera, :antikythera_instance_name)
   defun antikythera_instance_name() :: atom, do: @antikythera_instance_name
 
   @gear_action_timeout_default 10_000


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/258506

This fixes [Credo.Check.Warning.ApplicationConfigInModuleAttribute](https://hexdocs.pm/credo/Credo.Check.Warning.ApplicationConfigInModuleAttribute.html)