### PR TITLE
[284344] Bump up version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ which are exposed to antikythera instance administrators and/or gear developers.
 
 ---
 
-- Next minor version release:
+- 0.5.0:
     - Change backend of `mix antikythera_core.generate_release` from `relx` to `mix release`.
         - This requires manual addition of configs for `mix release` and renaming of related environment variables.
     - Upgrade Elixir to v1.11 series.
+    - Responses that should not have a body, such as 204, now raise an error if a non-empty body is given.
 - 0.4.0:
     - Add a new callback named `health_check_grace_period_in_seconds/0` to `AntikytheraEal.ClusterConfiguration.Behaviour`.
 - 0.3.0:

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Antikythera.Mixfile do
   def project() do
     [
       app: :antikythera,
-      version: Antikythera.MixCommon.version_with_last_commit_info("0.4.1"),
+      version: "0.5.0",
       elixirc_paths: elixirc_paths(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/284344

After merging this, I will do the following:

- `git tag 0.5.0 <commit hash>`
- `git push origin 0.5.0`
- `mix hex.publish`
- Fix [this line](https://github.com/access-company/antikythera/blob/16f189b2f3c53df340fb2ca3150174d1b43c4b4f/mix.exs#L44) by `version: Antikythera.MixCommon.version_with_last_commit_info("0.5.1"),`
- Update [antikythera_aws](/access-company/antikythera_aws)